### PR TITLE
Added Disposing event

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -2229,6 +2229,8 @@ type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<Provided
 
     let invalidateE = new Event<EventHandler,EventArgs>()    
 
+    let disposing = Event<EventHandler,EventArgs>()
+
 #if FX_NO_LOCAL_FILESYSTEM
 #else
     let probingFolders = ResizeArray()
@@ -2239,9 +2241,13 @@ type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<Provided
     new (namespaceName:string,types:list<ProvidedTypeDefinition>) = new TypeProviderForNamespaces([(namespaceName,types)])
     new () = new TypeProviderForNamespaces([])
 
+    [<CLIEvent>]
+    member this.Disposing = disposing.Publish
+
 #if FX_NO_LOCAL_FILESYSTEM
     interface System.IDisposable with 
-        member x.Dispose() = ()
+        member x.Dispose() = 
+            disposing.Trigger(x, EventArgs.Empty)
 #else
     abstract member ResolveAssembly : args : System.ResolveEventArgs -> Assembly
     default this.ResolveAssembly(args) = 
@@ -2262,8 +2268,11 @@ type TypeProviderForNamespaces(namespacesAndTypes : list<(string * list<Provided
         cfg.RuntimeAssembly
         |> IO.Path.GetDirectoryName
         |> this.RegisterProbingFolder
+
     interface System.IDisposable with 
-        member x.Dispose() = AppDomain.CurrentDomain.remove_AssemblyResolve handler
+        member x.Dispose() = 
+            disposing.Trigger(x, EventArgs.Empty)
+            AppDomain.CurrentDomain.remove_AssemblyResolve handler
 #endif
 
     member __.AddNamespace (namespaceName,types:list<_>) = otherNamespaces.Add (namespaceName,types)

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -425,6 +425,10 @@ type TypeProviderForNamespaces =
     member RegisterProbingFolder : folder : string -> unit
     /// Registers location of RuntimeAssembly (from TypeProviderConfig) as probing folder
     member RegisterRuntimeAssemblyLocationAsProbingFolder : cfg : Core.CompilerServices.TypeProviderConfig -> unit
+
 #endif
+
+    [<CLIEvent>]
+    member Disposing : IEvent<EventHandler,EventArgs>
 
     interface ITypeProvider


### PR DESCRIPTION
Added a Disposing event to the TypeProviderForNamespaces type.  This
allows type providers that require their own resource management to hook
into the IDisposable.Dispose call.

I used an event here instead of following the traditional dispose pattern with reason- 

I didn't want to add a `public Dispose(bool)` method on the type (for fear that it'd add confusion and people would call it), even though that was closed to the traditional Dispose pattern.  The traditional pattern is not possible in F#, since you can't control access to the method (ie: no protected member).  Using a Disposing event is something that has been done in the framework, as well (ie: Control.Disposing).  This also allows type providers which have externally controlled resources (such as the FileSystem TP) to manage disposal correctly.
