### PR TITLE
Updated comments in headers

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -1,3 +1,4 @@
+// Based on code for the F# 3.0 Developer Preview release of September 2011,
 // Copyright (c) Microsoft Corporation 2005-2012.
 // This sample code is provided "as is" without warranty of any kind. 
 // We disclaim all warranties, either express or implied, including the 
@@ -5,8 +6,8 @@
 
 // This file contains a set of helper types and methods for providing types in an implementation 
 // of ITypeProvider.
-//
-// This code is a sample for use in conjunction with the F# 3.0 Beta release of March 2012
+
+// This code has been modified and is appropriate for use in conjunction with the F# 3.0, F# 3.1, and F# 3.1.1 releases
 
 namespace ProviderImplementation.ProvidedTypes
 

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -1,12 +1,13 @@
-﻿// Copyright (c) Microsoft Corporation 2005-2012.
+﻿// Based on code developed for the F# 3.0 Beta release of March 2012,
+// Copyright (c) Microsoft Corporation 2005-2012.
 // This sample code is provided "as is" without warranty of any kind. 
 // We disclaim all warranties, either express or implied, including the 
 // warranties of merchantability and fitness for a particular purpose. 
 
 // This file contains a set of helper types and methods for providing types in an implementation 
 // of ITypeProvider.
-//
-// This code is a sample for use in conjunction with the F# 3.0 Developer Preview release of September 2011.
+
+// This code has been modified and is appropriate for use in conjunction with the F# 3.0, F# 3.1, and F# 3.1.1 releases
 
 
 namespace ProviderImplementation.ProvidedTypes


### PR DESCRIPTION
Trying to make it obvious that this is an appropriate starting point for writing type providers with F# 3.0/3.1/3.1.1.  Previous headers suggested that this may be very out of date, as they mentioned that the code was for use with the F# 3.0 beta releases.
