### PR TITLE
Additional testing and fixes related to Swagger provider

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -87,7 +87,7 @@ Target "RunTests" (fun _ ->
 #else
     exec "dotnet" ("test tests/FSharp.TypeProviders.SDK.Tests.fsproj -c " + config)
     // This also gives console output:
-    // dotnet build -c Debug  tests\FSharp.TypeProviders.SDK.Tests.fsproj && packages\xunit.runner.console\tools\net452\xunit.console.exe tests\bin\Debug\net461\FSharp.TypeProviders.SDK.Tests.dll -parallel none
+    // msbuild tests\FSharp.TypeProviders.SDK.Tests.fsproj /p:Configuration=Debug && packages\xunit.runner.console\tools\net452\xunit.console.exe tests\bin\Debug\net461\FSharp.TypeProviders.SDK.Tests.dll -parallel none
 #endif
     ()
 )

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -425,10 +425,10 @@ namespace ProviderImplementation.ProvidedTypes
     type ProvidedTypesContext = 
         
         /// Try to find the given target assembly in the context
-        member TryBindAssemblyNameToTgt: aref: AssemblyName -> Choice<Assembly, exn> 
+        member TryBindAssemblyNameToTarget: aref: AssemblyName -> Choice<Assembly, exn> 
 
         /// Try to find the given target assembly in the context
-        member TryBindSimpleAssemblyNameToTgt: assemblyName: string  -> Choice<Assembly, exn> 
+        member TryBindSimpleAssemblyNameToTarget: assemblyName: string  -> Choice<Assembly, exn> 
 
         /// Get the list of referenced assemblies determined by the type provider configuration
         member ReferencedAssemblyPaths: string list
@@ -454,7 +454,11 @@ namespace ProviderImplementation.ProvidedTypes
          /// this method should not be used directly when authoring a type provider.
         member ConvertSourceExprToTarget: Expr -> Expr
 
+        /// Read the assembly related to this context
+        member ReadRelatedAssembly: fileName: string -> Assembly
 
+        /// Read the assembly related to this context
+        member ReadRelatedAssembly: bytes: byte[] -> Assembly
 
     /// A base type providing default implementations of type provider functionality when all provided
     /// types are of type ProvidedTypeDefinition.

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -388,16 +388,47 @@ namespace ProviderImplementation.ProvidedTypes
         static member EraseType: typ:Type -> Type
 
 
+#if !NO_GENERATIVE
+    /// A provided generated assembly
+    type ProvidedAssembly =
+
+        inherit Assembly
+
+        /// Create a provided generated assembly
+        new: assemblyName: AssemblyName * assemblyFileName:string -> ProvidedAssembly
+
+        /// Create a provided generated assembly using a temporary file as the interim assembly storage
+        new: unit -> ProvidedAssembly
+
+        /// Emit the given provided type definitions as part of the assembly
+        /// and adjust the 'Assembly' property of all provided type definitions to return that
+        /// assembly.
+        ///
+        /// The assembly is only emitted when the Assembly property on the root type is accessed for the first time.
+        /// The host F# compiler does this when processing a generative type declaration for the type.
+        member AddTypes: types: ProvidedTypeDefinition list -> unit
+
+        /// <summary>
+        /// Emit the given nested provided type definitions as part of the assembly.
+        /// and adjust the 'Assembly' property of all provided type definitions to return that
+        /// assembly.
+        /// </summary>
+        /// <param name="enclosingTypeNames">A path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
+        member AddNestedTypes: types: ProvidedTypeDefinition list * enclosingGeneratedTypeNames: string list -> unit
+
+#endif
+
+
 
     [<Class>]
     /// Represents the context for which code is to be generated. Normally you should not need to use this directly.
     type ProvidedTypesContext = 
         
         /// Try to find the given target assembly in the context
-        member TryBindTargetAssembly: aref: AssemblyName -> Choice<Assembly, exn> 
+        member TryBindAssemblyNameToTgt: aref: AssemblyName -> Choice<Assembly, exn> 
 
         /// Try to find the given target assembly in the context
-        member TryBindTargetAssemblyBySimpleName: assemblyName: string  -> Choice<Assembly, exn> 
+        member TryBindSimpleAssemblyNameToTgt: assemblyName: string  -> Choice<Assembly, exn> 
 
         /// Get the list of referenced assemblies determined by the type provider configuration
         member ReferencedAssemblyPaths: string list
@@ -463,6 +494,13 @@ namespace ProviderImplementation.ProvidedTypes
 
 #endif
 
+#if !NO_GENERATIVE
+        /// Register that a given file is a provided generated target assembly, e.g. an assembly produced by an external
+        /// code generation tool.  This assembly should be a target assembly, i.e. use the same asssembly references
+        /// as given by TargetContext.ReferencedAssemblyPaths
+        member RegisterGeneratedTargetAssembly: fileName: string -> Assembly
+#endif
+
         [<CLIEvent>]
         member Disposing: IEvent<EventHandler,EventArgs>
 
@@ -472,48 +510,6 @@ namespace ProviderImplementation.ProvidedTypes
         member TargetContext: ProvidedTypesContext
 
         interface ITypeProvider
-
-
-#if !NO_GENERATIVE
-    /// A provided generated assembly
-    type ProvidedAssembly =
-
-        inherit Assembly
-
-        /// Create a provided generated assembly
-        new: assemblyName: AssemblyName * assemblyFileName:string * context:ProvidedTypesContext -> ProvidedAssembly
-
-        /// Create a provided generated assembly using a temporary file as the interim assembly storage
-        new: context:ProvidedTypesContext -> ProvidedAssembly
-
-        /// Emit the given provided type definitions as part of the assembly
-        /// and adjust the 'Assembly' property of all provided type definitions to return that
-        /// assembly.
-        ///
-        /// The assembly is only emitted when the Assembly property on the root type is accessed for the first time.
-        /// The host F# compiler does this when processing a generative type declaration for the type.
-        member AddTypes: types: ProvidedTypeDefinition list -> unit
-
-        /// <summary>
-        /// Emit the given nested provided type definitions as part of the assembly.
-        /// and adjust the 'Assembly' property of all provided type definitions to return that
-        /// assembly.
-        /// </summary>
-        /// <param name="enclosingTypeNames">A path of type names to wrap the generated types. The generated types are then generated as nested types.</param>
-        member AddNestedTypes: types: ProvidedTypeDefinition list * enclosingGeneratedTypeNames: string list -> unit
-
-        /// Get the corresponding assembly with respect to the target assemblies
-        member GetTargetAssembly: unit -> Assembly
-
-#if !FX_NO_LOCAL_FILESYSTEM
-        /// Register that a given file is a provided generated target assembly, e.g. an assembly produced by an external
-        /// code generation tool.  This assembly should be a target assembly, i.e. use the same asssembly references
-        /// as given by TargetContext.ReferencedAssemblyPaths
-        static member RegisterGeneratedTargetAssembly: context: ProvidedTypesContext * fileName: string -> Assembly
-#endif
-
-#endif
-
 
 
     module internal UncheckedQuotations =

--- a/tests/BasicErasedProvisionTests.fs
+++ b/tests/BasicErasedProvisionTests.fs
@@ -212,7 +212,7 @@ let ``Check target primitive types are identical to design-time types``() : unit
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTarget("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // primitive types with element types are ALWAYS equivalent the design-time types
     for tname, sourceType, _ in primitives do
         let targetType = mscorlib31.GetType(tname)
@@ -223,7 +223,7 @@ let ``Check target non-primitive types are different to design-time types``() : 
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTarget("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // non-primitive types should be _not_ be equal - we should see the target type in the referenced assemblies
     for tname, sourceType, _ in nonPrimitives do
         let targetType = mscorlib31.GetType(tname)
@@ -234,7 +234,7 @@ let ``Check type remapping functions work for primitives``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTarget("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     for tname, sourceType, _ in primitives do
         let targetType = mscorlib31.GetType(tname)
         Assert.Equal(targetType, tp.TargetContext.ConvertSourceTypeToTarget sourceType)
@@ -246,7 +246,7 @@ let ``Check type remapping functions work for nonPrimtives``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTarget("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     for tname, sourceType, _ in nonPrimitives do
         let targetType = mscorlib31.GetType(tname)
         // TODO: determine why this one is failing....
@@ -259,7 +259,7 @@ let ``Check can create Expr Value nodes for primitive types``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTarget("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // primitive types with element types are ALWAYS equivalent the design-time types
     for tname, _sourceType, sampleValue in primitives do
         let targetType = mscorlib31.GetType(tname)
@@ -274,7 +274,7 @@ let ``Check can't create Expr Value nodes for non-primitive types``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTarget("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // We expect Expr.Value to fail for non-primitive compile-time types.  This is a check in the F# quotations library
     for tname, _sourceType, sampleValue in nonPrimitives do
         try 

--- a/tests/BasicErasedProvisionTests.fs
+++ b/tests/BasicErasedProvisionTests.fs
@@ -10,7 +10,6 @@ module FSharp.TypeProviders.SDK.Tests.StaticProperty
 open System
 open System.IO
 open System.Reflection
-open ProviderImplementation
 open ProviderImplementation.ProvidedTypes
 open ProviderImplementation.ProvidedTypesTesting
 open Microsoft.FSharp.Core.CompilerServices
@@ -27,12 +26,12 @@ type ErasingProvider (config : TypeProviderConfig) as this =
 
     let createTypes () =
         let myType = ProvidedTypeDefinition(asm, ns, "MyType", Some typeof<obj>)
-        let myStaticGetterProp = ProvidedProperty("MyStaticGetterProperty", typeof<string list>, isStatic = true, getterCode = (fun args -> <@@ Set.ofList [ "Hello world" ] @@>))
-        let myStaticSetterProp = ProvidedProperty("MyStaticSetterProperty", typeof<string list>, isStatic = true, getterCode = (fun args -> <@@ Set.ofList [ "Hello world" ] @@>), setterCode = (fun args -> <@@ () @@>))
-        let myStaticMethod = ProvidedMethod("MyStaticMethod", [ ProvidedParameter("paramName",typeof<string list>) ], typeof<string list>, isStatic = true, invokeCode = (fun args -> <@@ Set.ofList [ "Hello world" ] @@>))
-        let myGetterProp = ProvidedProperty("MyGetterProperty", typeof<string list>, getterCode = (fun args -> <@@ Set.ofList [ "Hello world" ] @@>))
-        let mySetterProp = ProvidedProperty("MySetterProperty", typeof<string list>, getterCode = (fun args -> <@@ Set.ofList [ "Hello world" ] @@>), setterCode = (fun args -> <@@ () @@>))
-        let myMethod = ProvidedMethod("MyMethod", [ ProvidedParameter("paramName",typeof<string list>) ], typeof<string list>, invokeCode = (fun args -> <@@ Set.ofList [ "Hello world" ] @@>))
+        let myStaticGetterProp = ProvidedProperty("MyStaticGetterProperty", typeof<string list>, isStatic = true, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
+        let myStaticSetterProp = ProvidedProperty("MyStaticSetterProperty", typeof<string list>, isStatic = true, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>), setterCode = (fun _args -> <@@ () @@>))
+        let myStaticMethod = ProvidedMethod("MyStaticMethod", [ ProvidedParameter("paramName",typeof<string list>) ], typeof<string list>, isStatic = true, invokeCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
+        let myGetterProp = ProvidedProperty("MyGetterProperty", typeof<string list>, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
+        let mySetterProp = ProvidedProperty("MySetterProperty", typeof<string list>, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>), setterCode = (fun _args -> <@@ () @@>))
+        let myMethod = ProvidedMethod("MyMethod", [ ProvidedParameter("paramName",typeof<string list>) ], typeof<string list>, invokeCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
         myType.AddMembers [myStaticGetterProp; myStaticSetterProp; myGetterProp; mySetterProp]
         myType.AddMembers [myStaticMethod; myMethod ]
 
@@ -52,7 +51,7 @@ type ErasingConstructorProvider (config : TypeProviderConfig) as this =
     let createTypes () =
         let myType = ProvidedTypeDefinition(asm, ns, "MyType", Some typeof<obj>)
 
-        let ctor = ProvidedConstructor([], invokeCode = fun args -> <@@ ["My internal state"] :> obj @@>)
+        let ctor = ProvidedConstructor([], invokeCode = fun _args -> <@@ ["My internal state"] :> obj @@>)
         myType.AddMember(ctor)
 
         let ctor2 = ProvidedConstructor([ProvidedParameter("InnerState", typeof<string list>)], invokeCode = fun args -> <@@ (%%(args.[0]):string list) :> obj @@>)
@@ -73,9 +72,9 @@ type ErasingProviderWithStaticParams (config : TypeProviderConfig) as this =
     let ns = "StaticProperty.Provided"
     let asm = Assembly.GetExecutingAssembly()
 
-    let createType (typeName, n:int) =
+    let createType (typeName, _n:int) =
         let myType = ProvidedTypeDefinition(asm, ns, typeName, Some typeof<obj>)
-        let myProp = ProvidedProperty("MyGetterProperty", typeof<string list>, isStatic = true, getterCode = (fun args -> <@@ Set.ofList [ "Hello world" ] @@>))
+        let myProp = ProvidedProperty("MyGetterProperty", typeof<string list>, isStatic = true, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
         myType.AddMember(myProp)
         myType
 
@@ -204,16 +203,16 @@ let primitives =
       "System.Char",  typeof<char>, box '1' ]
 
 let nonPrimitives = 
-    [ "System.DateTime", typeof<System.DateTime>, box System.DateTime.Now
-      "System.TimeSpan", typeof<System.TimeSpan>, box System.TimeSpan.Zero
-      "System.DayOfWeek", typeof<System.DayOfWeek>, box System.DayOfWeek.Friday ]
+    [ "System.DateTime", typeof<DateTime>, box DateTime.Now
+      "System.TimeSpan", typeof<TimeSpan>, box TimeSpan.Zero
+      "System.DayOfWeek", typeof<DayOfWeek>, box DayOfWeek.Friday ]
 
 [<Fact>]
 let ``Check target primitive types are identical to design-time types``() : unit  = 
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindTargetAssemblyBySimpleName("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // primitive types with element types are ALWAYS equivalent the design-time types
     for tname, sourceType, _ in primitives do
         let targetType = mscorlib31.GetType(tname)
@@ -224,7 +223,7 @@ let ``Check target non-primitive types are different to design-time types``() : 
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindTargetAssemblyBySimpleName("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // non-primitive types should be _not_ be equal - we should see the target type in the referenced assemblies
     for tname, sourceType, _ in nonPrimitives do
         let targetType = mscorlib31.GetType(tname)
@@ -235,7 +234,7 @@ let ``Check type remapping functions work for primitives``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindTargetAssemblyBySimpleName("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     for tname, sourceType, _ in primitives do
         let targetType = mscorlib31.GetType(tname)
         Assert.Equal(targetType, tp.TargetContext.ConvertSourceTypeToTarget sourceType)
@@ -247,7 +246,7 @@ let ``Check type remapping functions work for nonPrimtives``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindTargetAssemblyBySimpleName("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     for tname, sourceType, _ in nonPrimitives do
         let targetType = mscorlib31.GetType(tname)
         // TODO: determine why this one is failing....
@@ -260,14 +259,14 @@ let ``Check can create Expr Value nodes for primitive types``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindTargetAssemblyBySimpleName("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // primitive types with element types are ALWAYS equivalent the design-time types
-    for tname, sourceType, sampleValue in primitives do
+    for tname, _sourceType, sampleValue in primitives do
         let targetType = mscorlib31.GetType(tname)
         Quotations.Expr.Value(sampleValue, targetType) |> ignore // does not throw
 
     // We expect Expr.Value to fail for non-primitive compile-time types.  This is a check in the F# quotations library
-    for tname, sourceType, sampleValue in nonPrimitives do
+    for _tname, sourceType, sampleValue in nonPrimitives do
        Quotations.Expr.Value(sampleValue, sourceType) |> ignore // no exception
 
 [<Fact>]
@@ -275,9 +274,9 @@ let ``Check can't create Expr Value nodes for non-primitive types``() : unit  =
     let refs = Targets.DotNet45FSharp31Refs()
     let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, refs.[0], refs)
     let tp = TypeProviderForNamespaces(cfg)
-    let mscorlib31 = match tp.TargetContext.TryBindTargetAssemblyBySimpleName("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
+    let mscorlib31 = match tp.TargetContext.TryBindSimpleAssemblyNameToTgt("mscorlib") with Choice1Of2 asm -> asm | Choice2Of2 err -> failwithf "couldn't bind mscorlib, err: %O" err
     // We expect Expr.Value to fail for non-primitive compile-time types.  This is a check in the F# quotations library
-    for tname, sourceType, sampleValue in nonPrimitives do
+    for tname, _sourceType, sampleValue in nonPrimitives do
         try 
            let targetType = mscorlib31.GetType(tname)
            Quotations.Expr.Value(sampleValue, targetType) |> ignore

--- a/tests/BasicGenerativeProvisionTests.fs
+++ b/tests/BasicGenerativeProvisionTests.fs
@@ -7,8 +7,6 @@ module FSharp.TypeProviders.SDK.Tests.BasicGenerativeTests
 #endif
 
 open System.Reflection
-open System.IO
-open ProviderImplementation
 open ProviderImplementation.ProvidedTypes
 open ProviderImplementation.ProvidedTypesTesting
 open Microsoft.FSharp.Quotations
@@ -25,8 +23,8 @@ type GenerativePropertyProviderWithStaticParams (config : TypeProviderConfig) as
 
     let ns = "StaticProperty.Provided"
     let asm = Assembly.GetExecutingAssembly()
-    let createType (typeName, n:int) =
-        let myAssem = ProvidedAssembly(this.TargetContext)
+    let createType (typeName, _) =
+        let myAssem = ProvidedAssembly()
         let myType = ProvidedTypeDefinition(myAssem, ns, typeName, Some typeof<obj>, isErased=false)
         let embedString = "test"
         // Special TPSDK support for embedding Decimal values
@@ -37,7 +35,7 @@ type GenerativePropertyProviderWithStaticParams (config : TypeProviderConfig) as
         let embedDTO = System.DateTimeOffset.Now
         // Special TPSDK support for embedding System.Type values
         let embedType = typeof<int>
-        let testCode args = 
+        let testCode _args = 
              <@@ // NewArray
                  let arr = [| 1;2;3;4 |]
                  // Coerce

--- a/tests/GenerativeEnumsProvisionTests.fs
+++ b/tests/GenerativeEnumsProvisionTests.fs
@@ -13,10 +13,8 @@ module FSharp.TypeProviders.SDK.Tests.GenerativeEnumsProvisionTests
 
 open System
 open System.Reflection
-open System.IO
 open Microsoft.FSharp.Core.CompilerServices
 open Xunit
-open ProviderImplementation
 open ProviderImplementation.ProvidedTypes
 open ProviderImplementation.ProvidedTypesTesting
 
@@ -26,8 +24,7 @@ type GenerativeEnumsProvider (config: TypeProviderConfig) as this =
     inherit TypeProviderForNamespaces (config)
 
     let ns = "Enums.Provided"
-    let asm = Assembly.GetExecutingAssembly()
-    let tempAssembly = ProvidedAssembly(this.TargetContext)
+    let tempAssembly = ProvidedAssembly()
     let container = ProvidedTypeDefinition(tempAssembly, ns, "Container", Some typeof<obj>, isErased = false)
 
     let createEnum name (values: list<string*int>) =
@@ -70,7 +67,7 @@ let testProvidedAssembly test =
         let assembly = Assembly.Load assemContents
         assembly.ExportedTypes |> Seq.find (fun ty -> ty.Name = "Container") |> test
 
-let runningOnMono = try System.Type.GetType("Mono.Runtime") <> null with e -> false 
+let runningOnMono = try Type.GetType("Mono.Runtime") <> null with _ -> false 
 
 [<Fact>]
 let ``Enums are generated correctly``() =


### PR DESCRIPTION
The Swagger provider does some interesting things like using one generated type as the base type for other generated types.   This causes lookups on the types implied by the generated assembly before generation is complete.

This PR adjusts the translation implementation of the SDK to allow for this, and adds a specific test case for this
