### PR TITLE
Add ProvidedParameter.AddCustomAttribute

### DIFF
--- a/examples/BasicProvider.Tests/BasicProvider.Tests.fs
+++ b/examples/BasicProvider.Tests/BasicProvider.Tests.fs
@@ -14,4 +14,8 @@ let ``Default constructor should create instance`` () =
 [<Fact>]
 let ``Constructor with parameter should create instance`` () =
     Assert.Equal("override", MyType("override").InnerState)
-    
+
+[<Fact>]
+let ``Method with ReflectedDefinition parameter should get its name`` () =
+    let myValue = 2
+    Assert.Equal("myValue", MyType.NameOf(myValue))

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -854,6 +854,7 @@ namespace ProviderImplementation.ProvidedTypes
         member __.OptionalValue = optionalValue 
         member __.HasDefaultParameterValue = Option.isSome optionalValue
         member __.BelongsToTargetModel = isTgt
+        member __.AddCustomAttribute(attribute) = customAttributesImpl.AddCustomAttribute(attribute)
 
         override __.Name = parameterName
         override __.ParameterType = parameterType

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -35,6 +35,9 @@ namespace ProviderImplementation.ProvidedTypes
         /// Indicates if the parameter has a default value
         member HasDefaultParameterValue: bool
 
+        /// Add a custom attribute to the provided parameter.
+        member AddCustomAttribute: CustomAttributeData -> unit
+
     /// Represents a provided static parameter.
     [<Class>]
     type ProvidedStaticParameter =


### PR DESCRIPTION
I have found this useful in particular to add `[<ReflectedDefinition>]` to a parameter.