### PR TITLE
Check if Base property on tcImports indeed exists inside ProvidedTypesContext.Create

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -8951,7 +8951,8 @@ namespace ProviderImplementation.ProvidedTypes
                 let baseObj = tcImports.GetProperty("Base")
 
                 [ for dllInfo in dllInfos.GetElements() -> (dllInfo.GetProperty("FileName") :?> string)
-                  for dllInfo in baseObj.GetProperty("Value").GetField("dllInfos").GetElements() -> (dllInfo.GetProperty("FileName") :?> string) ]
+                  if not (isNull baseObj) then
+                    for dllInfo in baseObj.GetProperty("Value").GetField("dllInfos").GetElements() -> (dllInfo.GetProperty("FileName") :?> string) ]
               with e ->
                 failwithf "Invalid host of cross-targeting type provider. Exception: %A" e
 


### PR DESCRIPTION
I have encountered the very same error as described in #177 in a different context: checking a project using a TP with FCS running inside an ASP.NET application (both the web application and and the checked project are targeting .NET 4.6).

I have found that a null check on `dllInfo` value inside `ProvidedTypesContext.Create` before using it eliminates this error and I could not find any regression.