### PR TITLE
fix for stackoverflow-exception...

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -7777,6 +7777,12 @@ namespace ProviderImplementation.ProvidedTypes
                     let ass2opt = tryBindAssembly(aref2)
                     match ass2opt with
                     | Choice1Of2 ass2 -> 
+                        if nsp.HasValue && nsp.Value="System" && nm = "Object" then 
+                            let rec fetchBase (t:Type) =
+                                if t.BaseType <> null then fetchBase t.BaseType
+                                else t
+                            asm.GetType() |> fetchBase |> Some
+                        else
                         match ass2.GetType(joinILTypeName nsp nm)  with 
                         | null -> None
                         | ty -> Some ty


### PR DESCRIPTION
...when compiling type-provider-user assembly to .net standard

This fixes the initial Stackoverflow problem of #182 but won't solve the other problems mentioned in the issue.

The idea here is that if asm is type of something-inheriting from System.Object, we can use the-most-basetype of that type as base class for System.Object, avoiding the stack overflow. I am naively expecting that asm type of System.Object is inherited from the correct dll (as the dll of System.Object is varying based on the asm runtime target, e.g. if you use Mono to build .NET Core compatible .NET Standard assembly).
