### PR TITLE
This will demonstrate the problem with .NET Standard type-provider

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -7777,6 +7777,12 @@ namespace ProviderImplementation.ProvidedTypes
                     let ass2opt = tryBindAssembly(aref2)
                     match ass2opt with
                     | Choice1Of2 ass2 -> 
+                        if nsp.HasValue && nsp.Value="System" && nm = "Object" then 
+                            let rec fetchBase (t:Type) =
+                                if t.BaseType <> null then fetchBase t.BaseType
+                                else t
+                            asm.GetType() |> fetchBase |> Some
+                        else
                         match ass2.GetType(joinILTypeName nsp nm)  with 
                         | null -> None
                         | ty -> Some ty

--- a/tests/BasicErasedProvisionTests.fs
+++ b/tests/BasicErasedProvisionTests.fs
@@ -28,11 +28,12 @@ type ErasingProvider (config : TypeProviderConfig) as this =
         let myType = ProvidedTypeDefinition(asm, ns, "MyType", Some typeof<obj>)
         let myStaticGetterProp = ProvidedProperty("MyStaticGetterProperty", typeof<string list>, isStatic = true, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
         let myStaticSetterProp = ProvidedProperty("MyStaticSetterProperty", typeof<string list>, isStatic = true, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>), setterCode = (fun _args -> <@@ () @@>))
+        let myStaticGetterProp2 = ProvidedProperty("MyStaticGetterProperty2", typeof<bigint>, isStatic = true, getterCode = (fun _args -> <@@ 34L @@>))
         let myStaticMethod = ProvidedMethod("MyStaticMethod", [ ProvidedParameter("paramName",typeof<string list>) ], typeof<string list>, isStatic = true, invokeCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
         let myGetterProp = ProvidedProperty("MyGetterProperty", typeof<string list>, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
         let mySetterProp = ProvidedProperty("MySetterProperty", typeof<string list>, getterCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>), setterCode = (fun _args -> <@@ () @@>))
         let myMethod = ProvidedMethod("MyMethod", [ ProvidedParameter("paramName",typeof<string list>) ], typeof<string list>, invokeCode = (fun _args -> <@@ Set.ofList [ "Hello world" ] @@>))
-        myType.AddMembers [myStaticGetterProp; myStaticSetterProp; myGetterProp; mySetterProp]
+        myType.AddMembers [myStaticGetterProp; myStaticGetterProp2; myStaticSetterProp; myGetterProp; mySetterProp]
         myType.AddMembers [myStaticMethod; myMethod ]
 
         [myType]

--- a/tests/FSharp.TypeProviders.SDK.Tests.fsproj
+++ b/tests/FSharp.TypeProviders.SDK.Tests.fsproj
@@ -1,7 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+     <TargetFrameworks>netcoreapp2.0;net461;netstandard2.0</TargetFrameworks>
      <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>NETSTANDARD</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <None Include="xunit.runner.json">

--- a/tests/Program.fs
+++ b/tests/Program.fs
@@ -1,2 +1,6 @@
 module Program 
+#if !NETSTANDARD
 let [<EntryPoint>] main _ = 0
+#else
+let main _ = 0
+#endif


### PR DESCRIPTION
This will demonstrate the current problem with type-provider assembly targeting to .NET Standard:

Project: 
 - FSharp.TypeProviders.SDK.Tests

Tests: 
 - ``ErasingProvider generates for .NET 4.5 F# 3.1 correctly``
 - ``ErasingProvider generates for .NET 4.5 F# 4.0 correctly``
 - ``ErasingProvider generates for Portable Profile 7 F# 4.0 correctly``

Message: System.Exception : The design-time type 'System.Numerics.BigInteger' utilized by a type provider was not found in the target reference assembly set 

Ping #177 and #182
  
  