### PR TITLE
fix 173 - missing assembly in source assembly set

### DIFF
--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -417,8 +417,11 @@ namespace ProviderImplementation.ProvidedTypes
         /// Get the resolved referenced assemblies determined by the type provider configuration
         member GetTargetAssemblies : unit -> Assembly[]
 
-        /// Get the set of design-time assemblies available to use as a basis for authoring provided types
+        /// Get the set of design-time assemblies available to use as a basis for authoring provided types.
         member GetSourceAssemblies : unit -> Assembly[]
+
+        /// Add an assembly to the set of design-time assemblies available to use as a basis for authoring provided types
+        member AddSourceAssembly : Assembly -> unit
 
         /// Try to get the version of FSharp.Core referenced. May raise an exception if FSharp.Core has not been correctly resolved
         member FSharpCoreAssemblyVersion: Version
@@ -441,15 +444,32 @@ namespace ProviderImplementation.ProvidedTypes
         /// Read the assembly related to this context
         member ReadRelatedAssembly: bytes: byte[] -> Assembly
 
-    /// A base type providing default implementations of type provider functionality when all provided
-    /// types are of type ProvidedTypeDefinition.
+    /// A base type providing default implementations of type provider functionality.
     type TypeProviderForNamespaces =
 
-        /// Initializes a type provider to provide the types in the given namespace.
-        new: config: TypeProviderConfig * namespaceName:string * types: ProvidedTypeDefinition list * ?assemblyReplacementMap: (string * string) list -> TypeProviderForNamespaces
+        /// <summary>Initializes a type provider to provide the types in the given namespace.</summary>
+        /// <param name="sourceAssemblies">
+        ///    Optionally specify the design-time assemblies available to use as a basis for authoring provided types.
+        ///    The transitive dependencies of these assemblies are also included. By default
+        ///    Assembly.GetCallingAssembly() and its transitive dependencies are used.
+        /// </param>
+        ///               
+        /// <param name="assemblyReplacementMap">
+        ///    Optionally specify a map of assembly names from source model to referenced assemblies.
+        /// </param>
+        new: config: TypeProviderConfig * namespaceName:string * types: ProvidedTypeDefinition list * ?sourceAssemblies: Assembly list * ?assemblyReplacementMap: (string * string) list -> TypeProviderForNamespaces
 
-        /// Initializes a type provider
-        new: config: TypeProviderConfig * ?assemblyReplacementMap: (string * string) list -> TypeProviderForNamespaces
+        /// <summary>Initializes a type provider.</summary>
+        /// <param name="sourceAssemblies">
+        ///    Optionally specify the design-time assemblies available to use as a basis for authoring provided types.
+        ///    The transitive dependencies of these assemblies are also included. By default
+        ///    Assembly.GetCallingAssembly() and its transitive dependencies are used.
+        /// </param>
+        ///               
+        /// <param name="assemblyReplacementMap">
+        ///    Optionally specify a map of assembly names from source model to referenced assemblies.
+        /// </param>
+        new: config: TypeProviderConfig * ?sourceAssemblies: Assembly list * ?assemblyReplacementMap: (string * string) list -> TypeProviderForNamespaces
 
         /// Invoked by the type provider to add a namespace of provided types in the specification of the type provider.
         member AddNamespace: namespaceName:string * types: ProvidedTypeDefinition list -> unit

--- a/src/ProvidedTypesTesting.fs
+++ b/src/ProvidedTypesTesting.fs
@@ -23,12 +23,12 @@ module Utils =
 
 /// Simulate a real host of TypeProviderConfig
 type internal DllInfo(path: string) =
-    member x.FileName = path
+    member __.FileName = path
 
 /// Simulate a real host of TypeProviderConfig
 type internal TcImports(bas: TcImports option, dllInfos: DllInfo list) =
-    member x.Base = bas
-    member x.DllInfos = dllInfos
+    member __.Base = bas
+    member __.DllInfos = dllInfos
 
 
 type internal Testing() =
@@ -684,7 +684,7 @@ module internal Targets =
              | Some res -> res
         
 
-    let private sysInstalledAssembliesPath profile =
+    let sysInstalledAssembliesPath profile =
         let portableRoot = if runningOnMono then monoRoot ++ "xbuild-frameworks" else referenceAssembliesPath ++ "Framework"
         match profile with
         | "net45"->
@@ -738,6 +738,7 @@ module internal Targets =
     let Portable7FSharp40Refs() = FSharpRefs "4.0" "portable7"
     let Portable78FSharp40Refs() = FSharpRefs "4.0" "portable78"
     let Portable259FSharp40Refs() = FSharpRefs "4.0" "portable259"
+    let DotNet45Ref r = sysInstalledAssembliesPath "net45" ++ r
 
     let FSharpCore41Ref() = FSharpCoreRef "4.1" "net45"
     let DotNet45FSharp41Refs() = FSharpRefs "4.1" "net45"

--- a/tests/BasicErasedProvisionTests.fs
+++ b/tests/BasicErasedProvisionTests.fs
@@ -371,7 +371,7 @@ let ``test basic binding context portable259``() =
        printfn "-=======================" 
    | Choice2Of2 err -> raise err
 
-
+#if !NETCOREAPP2_0
 [<Fact>]
 let ``test trasitive closure of source assemblies net45``() =
    let pf = Targets.DotNet45Ref "PresentationFramework.dll"
@@ -397,7 +397,7 @@ let ``test trasitive closure of source assemblies net45``() =
        // we use the transitive closure of assemblies.
        printfn "finding PresentationCore in source assemblies..."
        Assert.True(ctxt1.GetSourceAssemblies() |> Array.exists (fun a -> a.GetName().Name = "PresentationCore"))
-
+#endif
 
 [<Fact>]
 let ``test basic symbol type ops``() =

--- a/tests/BasicErasedProvisionTests.fs
+++ b/tests/BasicErasedProvisionTests.fs
@@ -388,7 +388,7 @@ let ``test trasitive closure of source assemblies net45``() =
        printfn "finding PresentationCore in targets..."
        Assert.True(ctxt1.GetTargetAssemblies() |> Array.exists (fun a -> a.GetName().Name = "PresentationCore"))
 
-       ctxt1.AddSourceAssembly(Assembly.LoadFrom(pf))
+       ctxt1.AddSourceAssembly(Assembly.Load(AssemblyName.GetAssemblyName(pf)))
 
        printfn "finding PresentationFramework in source assemblies..."
        Assert.True(ctxt1.GetSourceAssemblies() |> Array.exists (fun a -> a.GetName().Name = "PresentationFramework"))


### PR DESCRIPTION

The source assembly set was not being computed using transitive closure 