### PR TITLE
Neither Rider nor VS on OSX will load the BasicProvider projec…

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -33,7 +33,7 @@ let release =
     |> ReleaseNotesHelper.parseReleaseNotes
 
 let useMsBuildToolchain = environVar "USE_MSBUILD" <> null
-let dotnetSdkVersion = "2.1.100-preview-007363"
+let dotnetSdkVersion = "2.1.103"
 let sdkPath = lazy DotNetCli.InstallDotNetSDK dotnetSdkVersion
 let getSdkPath() = sdkPath.Value
 

--- a/examples/BasicProvider.DesignTime/BasicProvider.Provider.fs
+++ b/examples/BasicProvider.DesignTime/BasicProvider.Provider.fs
@@ -74,7 +74,7 @@ type BasicGenerativeProvider (config : TypeProviderConfig) as this =
         myType.AddMember(ctor2)
 
         for i in 1 .. count do 
-            let prop = ProvidedProperty("Property" + string i, typeof<int>, getterCode = fun args -> <@@ count @@>)
+            let prop = ProvidedProperty("Property" + string i, typeof<int>, getterCode = fun args -> <@@ i @@>)
             myType.AddMember(prop)
 
         let meth = ProvidedMethod("StaticMethod", [], typeof<BasicProvider.Helpers.SomeRuntimeHelper>, isStatic=true, invokeCode = (fun args -> Expr.Value(null, typeof<BasicProvider.Helpers.SomeRuntimeHelper>)))

--- a/examples/BasicProvider.Tests/BasicProvider.Tests.fs
+++ b/examples/BasicProvider.Tests/BasicProvider.Tests.fs
@@ -1,11 +1,11 @@
 #if INTERACTIVE
-#r @"../test/BasicProvider.dll"
+#r @"../BasicProvider/bin/Debug/netstandard2.0/BasicProvider.dll"
 #endif
 
 module BasicProvider.Tests
 
-open BasicProvider.Provided
 open Xunit
+open BasicProvider.Provided
 
 [<Fact>]
 let ``Default constructor should create instance`` () =

--- a/examples/BasicProvider.Tests/BasicProvider.Tests.fsproj
+++ b/examples/BasicProvider.Tests/BasicProvider.Tests.fsproj
@@ -5,6 +5,9 @@
      <IsPackable>false</IsPackable>
      <DefineConstants>NO_GENERATIVE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OtherFlags> --simpleresolution --nocopyfsharpcore --simpleresolution --nocopyfsharpcore</OtherFlags>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="BasicProvider.Tests.fs" />
     <Compile Include="Program.fs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0' " />

--- a/examples/BasicProvider/BasicProvider.fsproj
+++ b/examples/BasicProvider/BasicProvider.fsproj
@@ -17,11 +17,13 @@
 
     <!-- We place BOTH the net461 and netstandard2.0 design-time DLLs in well-known locations with resepct to the runtime DLL -->
     <!-- This enables any runtime DLL to be used with any host tooling running in either netcoreapp2.0+ or net461+ -->
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" Condition="'$(TargetFramework)' == 'net461'" />
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" Condition="'$(TargetFramework)' == 'netstandard2.0'" />  
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41\net461" Condition="'$(TargetFramework)' == 'net461'" />
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41\netstandard2.0" Condition="'$(TargetFramework)' == 'netstandard2.0'" />  
 
     <!-- We also place the net461 design-time DLLs alongside the runtime DLL for loading by legacy F# toolchains -->
+    <!-- for a definition of legacy, see: https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1003-loading-type-provider-design-time-components.md -->
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'net461'" />  
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> 
+    <!-- until the F# Tooling RFC above is implemented, the copy comand below is required for IDE based toolchains, when targetting standard. Warning --  this will overwrite the 4 legacy step above. Uncomment if you need it --> 
+    <!-- <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> -->
   </Target>  
 </Project>

--- a/examples/BasicProvider/BasicProvider.fsproj
+++ b/examples/BasicProvider/BasicProvider.fsproj
@@ -23,7 +23,7 @@
     <!-- We also place the net461 design-time DLLs alongside the runtime DLL for loading by legacy F# toolchains -->
     <!-- for a definition of legacy, see: https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1003-loading-type-provider-design-time-components.md -->
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'net461'" />  
-    <!-- until the F# Tooling RFC above is implemented, the copy comand below is required for IDE based toolchains, when targetting standard. Warning --  this will overwrite the 4 legacy step above. Uncomment if you need it --> 
+    <!-- until the F# Tooling RFC above is implemented, the copy comand below is required for IDE based toolchains, when targetting standard. Warning: this will overwrite the net4 legacy step above, when built last in a build sequence. Uncomment if you need it --> 
     <!-- <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> -->
   </Target>  
 </Project>

--- a/examples/BasicProvider/BasicProvider.fsproj
+++ b/examples/BasicProvider/BasicProvider.fsproj
@@ -1,18 +1,14 @@
-﻿<Project>
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <!-- See https://stackoverflow.com/questions/43921992/how-can-i-use-beforebuild-and-afterbuild-targets-with-visual-studio-2017 -->
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\..\netfx.props" />
-
   <PropertyGroup>
      <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
-
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
-
   <ItemGroup>
     <Compile Include="BasicProvider.Runtime.fs" />
   </ItemGroup>
-
   <Target Name="AfterBuild">  
     <!-- Note: BasicProvider.DesignTime.fsproj must have been built before this project -->
 
@@ -24,5 +20,4 @@
     <!-- We also place the net461 design-time DLLs alongside the runtime DLL for loading by legacy F# toolchains -->
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'net461'" />  
   </Target>  
-  
 </Project>

--- a/examples/BasicProvider/BasicProvider.fsproj
+++ b/examples/BasicProvider/BasicProvider.fsproj
@@ -18,11 +18,10 @@
     <!-- We place BOTH the net461 and netstandard2.0 design-time DLLs in well-known locations with resepct to the runtime DLL -->
     <!-- This enables any runtime DLL to be used with any host tooling running in either netcoreapp2.0+ or net461+ -->
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" Condition="'$(TargetFramework)' == 'net461'" />
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> 
-    
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> 
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" Condition="'$(TargetFramework)' == 'netstandard2.0'" />  
 
     <!-- We also place the net461 design-time DLLs alongside the runtime DLL for loading by legacy F# toolchains -->
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'net461'" />  
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> 
   </Target>  
 </Project>

--- a/examples/BasicProvider/BasicProvider.fsproj
+++ b/examples/BasicProvider/BasicProvider.fsproj
@@ -17,7 +17,7 @@
 
     <!-- We place BOTH the net461 and netstandard2.0 design-time DLLs in well-known locations with resepct to the runtime DLL -->
     <!-- This enables any runtime DLL to be used with any host tooling running in either netcoreapp2.0+ or net461+ -->
-    <!-- <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" /> -->
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" /> 
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" /> 
     
     <!-- <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" /> --> 

--- a/examples/BasicProvider/BasicProvider.fsproj
+++ b/examples/BasicProvider/BasicProvider.fsproj
@@ -6,7 +6,7 @@
      <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <OtherFlags> --simpleresolution --nocopyfsharpcore --simpleresolution --nocopyfsharpcore --lib:./typeproviders/fsharp41</OtherFlags>
+    <OtherFlags>--simpleresolution --nocopyfsharpcore --simpleresolution --nocopyfsharpcore --simpleresolution --nocopyfsharpcore --simpleresolution --nocopyfsharpcore</OtherFlags>
   </PropertyGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <ItemGroup>
@@ -17,10 +17,10 @@
 
     <!-- We place BOTH the net461 and netstandard2.0 design-time DLLs in well-known locations with resepct to the runtime DLL -->
     <!-- This enables any runtime DLL to be used with any host tooling running in either netcoreapp2.0+ or net461+ -->
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" /> 
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" /> 
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" Condition="'$(TargetFramework)' == 'net461'" />
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> 
     
-    <!-- <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" /> --> 
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'netstandard2.0'" /> 
 
     <!-- We also place the net461 design-time DLLs alongside the runtime DLL for loading by legacy F# toolchains -->
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'net461'" />  

--- a/examples/BasicProvider/BasicProvider.fsproj
+++ b/examples/BasicProvider/BasicProvider.fsproj
@@ -5,6 +5,9 @@
   <PropertyGroup>
      <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <OtherFlags> --simpleresolution --nocopyfsharpcore --simpleresolution --nocopyfsharpcore --lib:./typeproviders/fsharp41</OtherFlags>
+  </PropertyGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <ItemGroup>
     <Compile Include="BasicProvider.Runtime.fs" />
@@ -14,8 +17,10 @@
 
     <!-- We place BOTH the net461 and netstandard2.0 design-time DLLs in well-known locations with resepct to the runtime DLL -->
     <!-- This enables any runtime DLL to be used with any host tooling running in either netcoreapp2.0+ or net461+ -->
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41\net461" />  
-    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41\netstandard2.0" />  
+    <!-- <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" /> -->
+    <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)\typeproviders\fsharp41" /> 
+    
+    <!-- <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\netstandard2.0\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" /> --> 
 
     <!-- We also place the net461 design-time DLLs alongside the runtime DLL for loading by legacy F# toolchains -->
     <Copy SourceFiles="..\BasicProvider.DesignTime\bin\$(Configuration)\net461\BasicProvider.DesignTime.dll" DestinationFolder="$(OutputPath)" Condition="'$(TargetFramework)' == 'net461'" />  

--- a/examples/ComboProvider/ComboProvider.fs
+++ b/examples/ComboProvider/ComboProvider.fs
@@ -69,7 +69,7 @@ type ComboGenerativeProvider (config : TypeProviderConfig) as this =
         myType.AddMember(ctor2)
 
         for i in 1 .. count do 
-            let prop = ProvidedProperty("Property" + string i, typeof<int>, getterCode = fun args -> <@@ count @@>)
+            let prop = ProvidedProperty("Property" + string i, typeof<int>, getterCode = fun args -> <@@ i @@>)
             myType.AddMember(prop)
 
         let meth = ProvidedMethod("StaticMethod", [], typeof<SomeRuntimeHelper>, isStatic=true, invokeCode = (fun args -> Expr.Value(null, typeof<SomeRuntimeHelper>)))


### PR DESCRIPTION
Neither Rider nor VS on OSX will load the BasicProvider without the extra property setting of Sdk="Microsoft.NET.Sdk". The dependent projects BasicProvider.DesignTime and BasicProvider.Test is then prevented from compiling, at least, within an interactive "hit build" scenario. Note: this setting was copied across from the working ComboProvider.fsproj. But a minor fix.