### PR TITLE
fix perf of autocomplete for large member sets

### DIFF
--- a/examples/StressProvider.Tests/File1.fs
+++ b/examples/StressProvider.Tests/File1.fs
@@ -1,0 +1,7 @@
+﻿module File1
+
+
+open MyNamespace
+
+type Provided = Provider<"">
+let providedTags = Provided.Tags

--- a/examples/StressProvider.Tests/Program.fs
+++ b/examples/StressProvider.Tests/Program.fs
@@ -1,0 +1,2 @@
+module Program 
+let [<EntryPoint>] main _ = 0

--- a/examples/StressProvider.Tests/StressProvider.Tests.fs
+++ b/examples/StressProvider.Tests/StressProvider.Tests.fs
@@ -1,0 +1,8 @@
+#if INTERACTIVE
+#r @"../test/StressProvider.dll"
+#endif
+
+module StressProvider.Tests
+
+
+let x = File1.providedTags.

--- a/examples/StressProvider.Tests/StressProvider.Tests.fsproj
+++ b/examples/StressProvider.Tests/StressProvider.Tests.fsproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\netfx.props" />
+  <PropertyGroup>
+     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+     <IsPackable>false</IsPackable>
+     <DefineConstants>NO_GENERATIVE</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="File1.fs" />
+    <Compile Include="StressProvider.Tests.fs" />
+    <Compile Include="Program.fs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0' " />
+    <None Include="xunit.runner.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <ProjectReference Include="..\StressProvider\StressProvider.fsproj" />
+    
+  </ItemGroup>
+</Project>

--- a/examples/StressProvider.Tests/xunit.runner.json
+++ b/examples/StressProvider.Tests/xunit.runner.json
@@ -1,0 +1,3 @@
+{
+    "parallelizeTestCollections": false
+  }

--- a/examples/StressProvider/StressProvider.fs
+++ b/examples/StressProvider/StressProvider.fs
@@ -1,0 +1,44 @@
+
+namespace ProviderImplementation
+
+open ProviderImplementation
+open ProviderImplementation.ProvidedTypes
+open FSharp.Quotations
+open FSharp.Core.CompilerServices
+open System.Reflection
+
+
+type SomeRuntimeHelper() = 
+    static member Help() = "help"
+
+[<AllowNullLiteral>]
+type SomeRuntimeHelper2() = 
+    static member Help() = "help"
+
+[<TypeProvider>]
+type ComboErasingProvider (config : TypeProviderConfig) as this =
+    inherit TypeProviderForNamespaces (config)
+
+    let ns = "MyNamespace"
+    let asm = Assembly.GetExecutingAssembly()
+
+    let newProperty t name getter isStatic = ProvidedProperty(name, t, getter, isStatic = isStatic)
+    let newStaticProperty t name getter = newProperty t name (fun _ -> getter) true
+    let newInstanceProperty t name getter = newProperty t name (fun _ -> getter) false
+    let addStaticProperty t name getter (typ:ProvidedTypeDefinition) = typ.AddMember (newStaticProperty t name getter); typ
+    let addInstanceProperty t name getter (typ:ProvidedTypeDefinition) = typ.AddMember (newInstanceProperty t name getter); typ
+
+    let provider = ProvidedTypeDefinition(asm, ns, "Provider", Some typeof<obj>, hideObjectMethods = true)
+    let tags = ProvidedTypeDefinition(asm, ns, "Tags", Some typeof<obj>, hideObjectMethods = true)           
+    do [1..2000] |> Seq.iter (fun i -> addInstanceProperty typeof<int> (sprintf "Tag%d" i) <@@ i @@> tags |> ignore)
+
+    do provider.DefineStaticParameters([ProvidedStaticParameter("Host", typeof<string>)], fun name args ->
+        let provided = ProvidedTypeDefinition(asm, ns, name, Some typeof<obj>, hideObjectMethods = true)
+        addStaticProperty tags "Tags" <@@ obj() @@> provided |> ignore
+        provided
+    )
+
+    do this.AddNamespace(ns, [provider; tags])
+
+[<assembly:CompilerServices.TypeProviderAssembly()>]
+do ()

--- a/examples/StressProvider/StressProvider.fsproj
+++ b/examples/StressProvider/StressProvider.fsproj
@@ -1,0 +1,29 @@
+﻿<Project Sdk="Microsoft.NET.Sdk" >
+  <Import Project="..\..\netfx.props" />
+  <PropertyGroup>
+     <TargetFrameworks>netstandard2.0</TargetFrameworks>
+     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
+     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+     <Version>0.1</Version>
+     <!-- Use an explicit nuspec to allow us to specify "references", the metadata properties at https://docs.microsoft.com/en-us/dotnet/core/tools/csproj#nuget-metadata-properties don't allow this --> 
+     <NuspecFile>StressProvider.nuspec</NuspecFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\ProvidedTypes.fsi" />
+    <Compile Include="..\..\src\ProvidedTypes.fs" />
+    <Compile Include="StressProvider.fs" />
+
+    <!-- These files are the facades necessary to run .NET Standard 2.0 components on .NET Framework 4.6.1 (.NET Framework 4.7 will -->
+    <!-- come with these facades included). Because the type provider is a .NET Standard 2.0 component, the deployment of the type -->
+    <!--  provider must include these facade DLLs if it is to run hosted inside an F# compiler executing using  .NET Framework 4.6.1 or Mono 5.0. -->
+    <None Include="..\..\packages\NetStandard.Library.NetFramework\build\net461\lib\netstandard.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\packages\NetStandard.Library.NetFramework\build\net461\lib\System.Reflection.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\..\packages\NetStandard.Library.NetFramework\build\net461\lib\System.Runtime.dll">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>  
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Fixes perf problem #220 

We were quadratic for large collections of members, this makes it linear by saving the resolution of `GetMethods` and `GetProperties`