### PR TITLE
Added support for try-with and try-finally (fixes #241).

### DIFF
--- a/FSharp.TypeProviders.SDK.sln
+++ b/FSharp.TypeProviders.SDK.sln
@@ -17,6 +17,12 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "ComboProvider", "examples\C
 EndProject
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "StressProvider", "examples\StressProvider\StressProvider.fsproj", "{D9D3ED64-F4E3-4DCC-BD34-368BD9170F89}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{A17A2703-11E6-47A3-A1D7-13B0AD760947}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.TypeProviders.SDK.Tests.TypeProviders", "tests\TypeProviders\FSharp.TypeProviders.SDK.Tests.TypeProviders.fsproj", "{FD58089F-26FB-4DB9-8591-31CBD7C880F7}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.TypeProviders.SDK.Tests.Features", "tests\Features\FSharp.TypeProviders.SDK.Tests.Features.fsproj", "{DDAA5685-D230-4268-997A-896C4C2E65A5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +53,14 @@ Global
 		{D9D3ED64-F4E3-4DCC-BD34-368BD9170F89}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D9D3ED64-F4E3-4DCC-BD34-368BD9170F89}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D9D3ED64-F4E3-4DCC-BD34-368BD9170F89}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD58089F-26FB-4DB9-8591-31CBD7C880F7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD58089F-26FB-4DB9-8591-31CBD7C880F7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD58089F-26FB-4DB9-8591-31CBD7C880F7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD58089F-26FB-4DB9-8591-31CBD7C880F7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DDAA5685-D230-4268-997A-896C4C2E65A5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DDAA5685-D230-4268-997A-896C4C2E65A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DDAA5685-D230-4268-997A-896C4C2E65A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DDAA5685-D230-4268-997A-896C4C2E65A5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -56,6 +70,8 @@ Global
 		{8A9470AA-303A-40D3-813C-1B6563EDB573} = {E5E5268B-0B72-41FE-9747-5CEBEE3EB161}
 		{E1762555-BA7F-4E6A-A2ED-CE7977494563} = {E5E5268B-0B72-41FE-9747-5CEBEE3EB161}
 		{D9D3ED64-F4E3-4DCC-BD34-368BD9170F89} = {E5E5268B-0B72-41FE-9747-5CEBEE3EB161}
+		{FD58089F-26FB-4DB9-8591-31CBD7C880F7} = {A17A2703-11E6-47A3-A1D7-13B0AD760947}
+		{DDAA5685-D230-4268-997A-896C4C2E65A5} = {A17A2703-11E6-47A3-A1D7-13B0AD760947}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {469ECCE5-A55C-473A-B332-1D90D3977EFD}

--- a/build.fsx
+++ b/build.fsx
@@ -79,11 +79,14 @@ Target "Build" (fun _ ->
   if useMsBuildToolchain then
     DotNetCli.Restore  (fun p -> { p with Project = "src/FSharp.TypeProviders.SDK.fsproj"; ToolPath =  getSdkPath() })
     DotNetCli.Restore  (fun p -> { p with Project = "tests/FSharp.TypeProviders.SDK.Tests.fsproj"; ToolPath =  getSdkPath() })
+    DotNetCli.Restore  (fun p -> { p with Project = "tests/Features/FSharp.TypeProviders.SDK.Tests.Features.fsproj"; ToolPath =  getSdkPath() })
     MSBuildRelease null "Build" ["src/FSharp.TypeProviders.SDK.fsproj"] |> Log "Build-Output: "
     MSBuildRelease null "Build" ["tests/FSharp.TypeProviders.SDK.Tests.fsproj"] |> Log "Build-Output: "
+    MSBuildRelease null "Build" ["tests/Features/FSharp.TypeProviders.SDK.Tests.Features.fsproj"] |> Log "Build-Output: "
   else
     DotNetCli.Build  (fun p -> { p with Configuration = config; Project = "src/FSharp.TypeProviders.SDK.fsproj"; ToolPath =  getSdkPath() })
     DotNetCli.Build  (fun p -> { p with Configuration = config; Project = "tests/FSharp.TypeProviders.SDK.Tests.fsproj"; ToolPath =  getSdkPath() })
+    DotNetCli.Build  (fun p -> { p with Configuration = config; Project = "tests/Features/FSharp.TypeProviders.SDK.Tests.Features.fsproj"; ToolPath =  getSdkPath() })
 )
 
 Target "Examples" (fun _ ->
@@ -123,6 +126,7 @@ Target "RunTests" (fun _ ->
     // msbuild tests/FSharp.TypeProviders.SDK.Tests.fsproj /p:Configuration=Debug && mono packages/xunit.runner.console/tools/net452/xunit.console.exe tests/bin/Debug/net461/FSharp.TypeProviders.SDK.Tests.dll -parallel none
 #else
     DotNetCli.Test  (fun p -> { p with Configuration = config; Project = "tests/FSharp.TypeProviders.SDK.Tests.fsproj"; ToolPath =  getSdkPath() })
+    DotNetCli.Test  (fun p -> { p with Configuration = config; Project = "tests/Features/FSharp.TypeProviders.SDK.Tests.Features.fsproj"; ToolPath =  getSdkPath() })
     DotNetCli.Test  (fun p -> { p with Configuration = config; Project = "examples/BasicProvider.Tests/BasicProvider.Tests.fsproj"; ToolPath =  getSdkPath() })
     DotNetCli.Test  (fun p -> { p with Configuration = config; Project = "examples/ComboProvider.Tests/ComboProvider.Tests.fsproj"; ToolPath =  getSdkPath() })
 

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -13200,21 +13200,34 @@ namespace ProviderImplementation.ProvidedTypes
 
     type ILLocalBuilder(i: int) =
         member __.LocalIndex = i
+    
+    [<RequireQualifiedAccess>]
+    type ILExceptionClauseBuilder =
+        | Finally of ILCodeLabel
+        | Fault of ILCodeLabel
+        | FilterCatch of ILCodeLabel * (ILCodeLabel * ILCodeLabel)
+        | TypeCatch of ILCodeLabel * ILType
+
+    type ILExceptionBlockBuilder(i: ILCodeLabel) =
+        member __.StartIndex = i
+        member val Clause : ILExceptionClauseBuilder option = None with get, set
 
     type ILGenerator(methodName) =
         let mutable locals =  ResizeArray<ILLocal>()
         let mutable instrs =  ResizeArray<ILInstr>()
+        let mutable exceptions = ResizeArray<ILExceptionSpec>()
         let mutable labelCount =  0
         let mutable labels =  Dictionary<ILCodeLabel,int>()
+        let mutable exceptionBlocks = Stack<ILExceptionBlockBuilder>()
 
         member __.Content = 
             { IsZeroInit = true
               MaxStack = instrs.Count
               Locals = locals.ToArray()
               Code = 
-                { Labels=labels
-                  Instrs=instrs.ToArray()
-                  Exceptions = [| |] // TODO
+                { Labels = labels
+                  Instrs = instrs.ToArray()
+                  Exceptions = exceptions.ToArray()
                   Locals = [| |] (* TODO ILLocalDebugInfo *) }
              }
 
@@ -13223,6 +13236,42 @@ namespace ProviderImplementation.ProvidedTypes
             let local = { Type = ty; IsPinned = false; DebugInfo = None }
             locals.Add(local)
             ILLocalBuilder(idx)
+        
+        member __.BeginExceptionBlock() =
+            exceptionBlocks.Push(ILExceptionBlockBuilder(instrs.Count))
+        
+        member __.BeginCatchBlock(typ: ILType) =
+            exceptionBlocks.Peek().Clause <- Some <|
+                ILExceptionClauseBuilder.TypeCatch(instrs.Count, typ)
+    
+        member __.BeginCatchFilterBlock(range: ILCodeLabel * ILCodeLabel) =
+            exceptionBlocks.Peek().Clause <- Some <|
+                ILExceptionClauseBuilder.FilterCatch(instrs.Count, range)
+        
+        member __.BeginFinallyBlock() =
+            exceptionBlocks.Peek().Clause <- Some <|
+                ILExceptionClauseBuilder.Finally instrs.Count
+    
+        member __.BeginFaultBlock() =
+            exceptionBlocks.Peek().Clause <- Some <|
+                ILExceptionClauseBuilder.Fault instrs.Count
+        
+        member __.EndExceptionBlock() =
+            let exnBlock = exceptionBlocks.Pop()
+            let endIndex = instrs.Count
+            let clause = match exnBlock.Clause.Value with
+                         | ILExceptionClauseBuilder.Finally(start) ->
+                            ILExceptionClause.Finally (start, endIndex)
+                         | ILExceptionClauseBuilder.Fault(start) ->
+                            ILExceptionClause.Fault (start, endIndex)
+                         | ILExceptionClauseBuilder.FilterCatch(start, range) ->
+                            ILExceptionClause.FilterCatch (range, (start, endIndex))
+                         | ILExceptionClauseBuilder.TypeCatch(start, typ) ->
+                            ILExceptionClause.TypeCatch(typ, (start, endIndex))
+        
+            exceptions.Add { Range  = (exnBlock.StartIndex, endIndex)
+                           ; Clause = clause
+                           }
 
         member __.DefineLabel() = labelCount <- labelCount + 1; labelCount
         member __.MarkLabel(label) = labels.[label] <- instrs.Count
@@ -13842,7 +13891,6 @@ namespace ProviderImplementation.ProvidedTypes
                 ilg.Emit(I_nop)
                 ilg.MarkLabel(endLabel)
 
-#if EMIT_TRY_WITH
             | TryWith(body, _filterVar, _filterBody, catchVar, catchBody) ->
 
                 let stres, ldres =
@@ -13854,9 +13902,9 @@ namespace ProviderImplementation.ProvidedTypes
                         stres, ldres
 
                 let exceptionVar = ilg.DeclareLocal(transType catchVar.Type)
-                locals.Add(catchVar, exceptionVar)
+                localsMap.Add(catchVar, exceptionVar)
 
-                let _exnBlock = ilg.BeginExceptionBlock()
+                ilg.BeginExceptionBlock()
 
                 emitExpr expectedState body
                 stres()
@@ -13868,7 +13916,29 @@ namespace ProviderImplementation.ProvidedTypes
                 ilg.EndExceptionBlock()
 
                 ldres()
-#endif
+
+            | TryFinally(body, finallyBody) ->
+
+                let stres, ldres =
+                    if isEmpty expectedState then ignore, ignore
+                    else
+                        let local = ilg.DeclareLocal (transType body.Type)
+                        let stres = fun () -> ilg.Emit(I_stloc local.LocalIndex)
+                        let ldres = fun () -> ilg.Emit(I_ldloc local.LocalIndex)
+                        stres, ldres
+                
+                ilg.BeginExceptionBlock() |> ignore
+
+                emitExpr expectedState body
+                stres()
+
+                ilg.BeginFinallyBlock() |> ignore
+
+                emitExpr expectedState finallyBody
+
+                ilg.EndExceptionBlock()
+
+                ldres()
 
             | VarSet(v,e) ->
                 emitExpr ExpectedStackState.Value e

--- a/tests/Features/FSharp.TypeProviders.SDK.Tests.Features.fsproj
+++ b/tests/Features/FSharp.TypeProviders.SDK.Tests.Features.fsproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\netfx.props" />
+  <PropertyGroup>
+     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
+     <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="TryWithFinally.fs" />
+    <Compile Include="..\Program.fs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp2.0' " />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170517-02" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <ProjectReference Include="..\TypeProviders\FSharp.TypeProviders.SDK.Tests.TypeProviders.fsproj" />
+    <Reference Condition=" '$(TargetFramework)' == 'net461' " Include="System.Private.CoreLib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e" />
+  </ItemGroup>
+</Project>

--- a/tests/Features/TryWithFinally.fs
+++ b/tests/Features/TryWithFinally.fs
@@ -1,0 +1,27 @@
+module TryWithFinally
+
+open System
+open Tests
+open Xunit
+
+type TestType = TryWithFinallyProvider<"unused">
+
+[<Fact>]
+let ``TryWith and TryFinally expressions are supported``() =
+    // Now for the actual tests...
+    let mutable wasDisposed = false
+
+    let notifyOnDeath = { new IDisposable with
+        member __.Dispose() = wasDisposed <- true
+    }
+
+    let status = TestType.TestNonThrowing()
+
+    Assert.Equal(status, 0)
+
+    let exn = Assert.Throws<Exception>(Action(fun () ->
+        TestType.TestThrowing(notifyOnDeath) |> ignore
+    ))
+
+    Assert.Equal(exn.Message, "This will throw and dispose the given argument.")
+    Assert.Equal(wasDisposed, true)

--- a/tests/TypeProviders/FSharp.TypeProviders.SDK.Tests.TypeProviders.fsproj
+++ b/tests/TypeProviders/FSharp.TypeProviders.SDK.Tests.TypeProviders.fsproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="..\..\netfx.props" />
+  <PropertyGroup>
+     <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+     <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\src\ProvidedTypes.fsi">
+      <Link>ProvidedTypes.fsi</Link>
+    </Compile>
+    <Compile Include="..\..\src\ProvidedTypes.fs">
+      <Link>ProvidedTypes.fs</Link>
+    </Compile>
+    <Compile Include="Library.fs" />
+    <Compile Include="TryWithFinallyTypeProvider.fs" />
+  </ItemGroup>
+</Project>

--- a/tests/TypeProviders/Library.fs
+++ b/tests/TypeProviders/Library.fs
@@ -1,0 +1,6 @@
+namespace FSharp.TypeProviders.SDK.Tests.TypeProviders
+
+open Microsoft.FSharp.Core.CompilerServices
+
+[<assembly: TypeProviderAssembly>]
+do ()

--- a/tests/TypeProviders/TryWithFinallyTypeProvider.fs
+++ b/tests/TypeProviders/TryWithFinallyTypeProvider.fs
@@ -1,0 +1,82 @@
+namespace FSharp.TypeProviders.SDK.Tests.TypeProviders
+
+open System
+
+open ProviderImplementation.ProvidedTypes
+open Microsoft.FSharp.Core.CompilerServices
+
+#nowarn "0025"
+
+[<TypeProvider>]
+type TypeProviderWithTryWithFinally(config : TypeProviderConfig) as this =
+    inherit TypeProviderForNamespaces(config)
+
+    let ns = "Tests"
+    let asm = System.Reflection.Assembly.GetExecutingAssembly()
+
+    let provider = ProvidedTypeDefinition(asm, ns, "TryWithFinallyProvider", Some typeof<obj>)
+
+    do provider.DefineStaticParameters([ProvidedStaticParameter("Host", typeof<string>)], fun name _ ->
+        let provided = ProvidedTypeDefinition(asm, ns, name, Some typeof<obj>)
+
+        let providedParameters = [
+            ProvidedParameter("disp", typeof<IDisposable>)
+        ]
+
+        ProvidedMethod("TestThrowing", providedParameters, typeof<int>, fun [ arg ] ->
+            <@@
+                use __ = (%%arg : IDisposable)
+
+                failwith "This will throw and dispose the given argument."
+                0
+            @@>
+        , isStatic = true) |> provided.AddMember
+        
+        ProvidedMethod("TestNonThrowing", [], typeof<int>, fun [] ->
+            <@@
+                try
+                    raise <| ArgumentException("Throwing exception...")
+                with
+                | :? ArgumentException as exn when exn.Message = "Throwing an exception..." ->
+                    let mutable status = 3
+
+                    try
+                        try
+                            failwith "Failing"
+                        finally
+                            status <- 2
+                    with _ ->
+                        assert(status = 2)
+
+                        status <- 1
+                    
+                    assert(status = 1)
+
+                    try
+                        try
+                            failwith "This will not get caught."
+                        with
+                        | :? ArgumentException -> status <- 5
+                        | exn when exn.Message = "This will get caught." -> status <- 6
+                    with
+                    | _ -> assert(status = 1) // Status shouldn't have changed.
+
+                    assert(status = 1)
+
+                    status <-
+                        try
+                            try
+                                failwith "Nope."
+                            with
+                            | _ -> 0
+                        with
+                        | _ -> -1
+                    
+                    status
+            @@>
+        , isStatic = true) |> provided.AddMember
+
+        provided
+    )
+
+    do this.AddNamespace(ns, [provider])


### PR DESCRIPTION
This adds support for `Expr.TryFinally` and `Expr.TryWith`, as well as support for exception blocks in the `ILGenerator`.

The following provider was used to test the try blocks:
```fs
namespace FSharp.TypeProviders.SDK.Testing

open ProviderImplementation.ProvidedTypes
open FSharp.Core.CompilerServices

open System
open System.Reflection

[<TypeProvider>]
type ComboErasingProvider(config : TypeProviderConfig) as this =
    inherit TypeProviderForNamespaces(config)

    let ns = "Tests"
    let asm = Assembly.GetExecutingAssembly()

    let provider = ProvidedTypeDefinition(asm, ns, "Provider", Some typeof<obj>, hideObjectMethods = true)

    do provider.DefineStaticParameters([ProvidedStaticParameter("Host", typeof<string>)], fun name _ ->
        let provided = ProvidedTypeDefinition(asm, ns, name, Some typeof<obj>, hideObjectMethods = true)

        let fn = ProvidedMethod("Test", [ ProvidedParameter("disp", typeof<IDisposable>) ], typeof<System.Void>, fun [ arg ] ->
            <@@
                use __ = (%%arg : IDisposable)

                try
                    failwith "This will throw anyway, don't mind it."

                    printfn "[-] Should not get here."
                finally
                    printfn "[+] Caught try-finally, nice."

                    try
                        failwith "It failed again."

                        printf "[-] Should not get here."
                    with
                    | _ ->
                        printfn "[+] Caught try-with, nice."

                    try
                        printfn "[?] Gonna go to finally without throwing..."
                    finally
                        printfn "[+] Yup, it worked totally."
            @@>
        , isStatic = true)

        provided.AddMember fn
        provided
    )

    do this.AddNamespace(ns, [provider])

[<assembly: TypeProviderAssembly>]
do ()
```

The following script was used to test the provider:
```fs
#r "bin/Debug/netstandard2.0/FSharp.TypeProviders.SDK.Testing.dll"
open System

type TestType = Tests.Provider<"Doesn't matter">

let notifyOnDeath = { new IDisposable with
    member __.Dispose() = printfn "[+] Disposable was killed in 'use' block."
}

TestType.Test(notifyOnDeath)
```

Output:
```
[+] Caught try-finally, nice.
[+] Caught try-with, nice.
[?] Gonna go to finally without throwing...
[+] Yup, it worked totally.
[+] Disposable was killed in 'use' block.
System.Exception: This will throw anyway, don't mind it.
   at <StartupCode$FSI_0001>.$FSI_0001.main@() in D:\Media\OneDrive\Code\FSharp.TypeProviders.SDK.Testing\Test.fsx:line 10
Stopped due to error
```

**Edit**: Two questions:
1. Should I add the tests somewhere in this repository? I haven't seen much tests in the codebase which is why I used a separate project to test my stuff.
2. My tests don't cover every possible case, do you want me to take care of that?