### PR TITLE
1. changed signature of AddMember be of Flexible Type #MemberInfo ins…

### DIFF
--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -319,7 +319,7 @@ namespace ProviderImplementation.ProvidedTypes
         member SetAttributes: TypeAttributes -> unit
 
         /// Add a method, property, nested type or other member to a ProvidedTypeDefinition
-        member AddMember: memberInfo:MemberInfo      -> unit
+        member AddMember: memberInfo:#MemberInfo      -> unit
 
         /// Add a set of members to a ProvidedTypeDefinition
         member AddMembers: memberInfos:list<#MemberInfo> -> unit
@@ -340,13 +340,13 @@ namespace ProviderImplementation.ProvidedTypes
         member AddDefinitionLocation: line:int * column:int * filePath:string -> unit
 
         /// Suppress Object entries in intellisense menus in instances of this provided type
-        member HideObjectMethods: bool 
+        member HideObjectMethods: bool
 
         /// Disallows the use of the null literal.
         member NonNullable: bool
 
         /// Get a flag indicating if the ProvidedTypeDefinition is erased
-        member IsErased: bool 
+        member IsErased: bool
 
         /// Get or set a flag indicating if the ProvidedTypeDefinition has type-relocation suppressed
         [<Experimental("SuppressRelocation is a workaround and likely to be removed")>]
@@ -403,13 +403,13 @@ namespace ProviderImplementation.ProvidedTypes
 
     [<Class>]
     /// Represents the context for which code is to be generated. Normally you should not need to use this directly.
-    type ProvidedTypesContext = 
-        
-        /// Try to find the given target assembly in the context
-        member TryBindAssemblyNameToTarget: aref: AssemblyName -> Choice<Assembly, exn> 
+    type ProvidedTypesContext =
 
         /// Try to find the given target assembly in the context
-        member TryBindSimpleAssemblyNameToTarget: assemblyName: string  -> Choice<Assembly, exn> 
+        member TryBindAssemblyNameToTarget: aref: AssemblyName -> Choice<Assembly, exn>
+
+        /// Try to find the given target assembly in the context
+        member TryBindSimpleAssemblyNameToTarget: assemblyName: string  -> Choice<Assembly, exn>
 
         /// Get the list of referenced assemblies determined by the type provider configuration
         member ReferencedAssemblyPaths: string list
@@ -453,7 +453,7 @@ namespace ProviderImplementation.ProvidedTypes
         ///    The transitive dependencies of these assemblies are also included. By default
         ///    Assembly.GetCallingAssembly() and its transitive dependencies are used.
         /// </param>
-        ///               
+        ///
         /// <param name="assemblyReplacementMap">
         ///    Optionally specify a map of assembly names from source model to referenced assemblies.
         /// </param>
@@ -465,7 +465,7 @@ namespace ProviderImplementation.ProvidedTypes
         ///    The transitive dependencies of these assemblies are also included. By default
         ///    Assembly.GetCallingAssembly() and its transitive dependencies are used.
         /// </param>
-        ///               
+        ///
         /// <param name="assemblyReplacementMap">
         ///    Optionally specify a map of assembly names from source model to referenced assemblies.
         /// </param>
@@ -510,7 +510,7 @@ namespace ProviderImplementation.ProvidedTypes
         member Disposing: IEvent<EventHandler,EventArgs>
 
         /// The context for which code is eventually to be generated. You should not normally
-        /// need to use this property directly, as translation from the compiler-hosted context to 
+        /// need to use this property directly, as translation from the compiler-hosted context to
         /// the design-time context will normally be performed automatically.
         member TargetContext: ProvidedTypesContext
 


### PR DESCRIPTION
…tead of MemberInfo as a convenience

2. altered the behaviour of the AddMember and AddMemberDelayed, so that each item of a list is patched then queued, not the list patched completely, then queued completely. The difference is subtle, but it appears to be necessary. Previously, if a .ctor was in the member list, while using AddMembers, you'd get an exception. Clue: possibly related to a depth-first creation strategy, but this was also replicated in simpler cases. This is the closest I've come to fixing a root cause without delving deeply into IL. NB. note that TP authors add the .ctor as a separate step. Eventually, I'll be aiming at a fable-like DSL for TPs (stay tuned). This fix is related to that.