### PR TITLE
Add NewUnionCaseUnchecked, also adjust PropertySetUnchecked to have the same signature as PropertySet

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -345,6 +345,8 @@ namespace ProviderImplementation.ProvidedTypes
         assert (whileLoopOp |> isNull |> not)
         let ifThenElseOp = qTy.GetMethod("get_IfThenElseOp", bindAll)
         assert (ifThenElseOp |> isNull |> not)
+        let newUnionCaseOp = qTy.GetMethod("NewNewUnionCaseOp", bindAll)
+        assert (newUnionCaseOp |> isNull |> not)
 
         type Microsoft.FSharp.Quotations.Expr with
 
@@ -387,7 +389,8 @@ namespace ProviderImplementation.ProvidedTypes
                 let op = staticPropSetOp.Invoke(null, [| box pinfo |])
                 mkFEN.Invoke(null, [| box op; box (args@[value]) |]) :?> Expr
 
-            static member PropertySetUnchecked (obj: Expr, pinfo: PropertyInfo, value: Expr, args: Expr list) =
+            static member PropertySetUnchecked (obj: Expr, pinfo: PropertyInfo, value: Expr, ?args: Expr list) =
+                let args = defaultArg args []
                 let op = instancePropSetOp.Invoke(null, [| box pinfo |])
                 mkFEN.Invoke(null, [| box op; box (obj::(args@[value])) |]) :?> Expr
 
@@ -428,6 +431,10 @@ namespace ProviderImplementation.ProvidedTypes
             static member IfThenElseUnchecked (e:Expr, t:Expr, f:Expr) = 
                 let op = ifThenElseOp.Invoke(null, [| |])
                 mkFE3.Invoke(null, [| box op; box e; box t; box f |] ):?> Expr
+
+            static member NewUnionCaseUnchecked (uci:Reflection.UnionCaseInfo, args:Expr list) = 
+                let op = newUnionCaseOp.Invoke(null, [| box uci |])
+                mkFEN.Invoke(null, [| box op; box args |]) :?> Expr
                 
         type Shape = Shape of (Expr list -> Expr)
 

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -529,7 +529,7 @@ namespace ProviderImplementation.ProvidedTypes
         static member PropertyGetUnchecked: pinfo:PropertyInfo * args:Expr list -> Expr
         static member PropertyGetUnchecked: obj:Expr * pinfo:PropertyInfo * ?args:Expr list -> Expr
         static member PropertySetUnchecked: pinfo:PropertyInfo * value:Expr * ?args:Expr list -> Expr
-        static member PropertySetUnchecked: obj:Expr * pinfo:PropertyInfo * value:Expr * args:Expr list -> Expr
+        static member PropertySetUnchecked: obj:Expr * pinfo:PropertyInfo * value:Expr * ?args:Expr list -> Expr
         static member FieldGetUnchecked: pinfo:FieldInfo -> Expr
         static member FieldGetUnchecked: obj:Expr * pinfo:FieldInfo -> Expr
         static member FieldSetUnchecked: pinfo:FieldInfo * value:Expr -> Expr


### PR DESCRIPTION
This allows the use of NewUnionCaseUnchecked, also the PR unifies the API so that PropertySetUnchecked has the same signature as PropertySet - `args` being optional.