### PR TITLE
check 'this' for generative constructors, add try/finally with fixes

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -8890,6 +8890,9 @@ namespace ProviderImplementation.ProvidedTypes
 
         and convCodeToTgt (codeFun: Expr list -> Expr, isStatic, isCtor, parameters: ProvidedParameter[], isGenerated) = 
             (fun argsT -> 
+                // argsT: the target arg expressions coming from host tooling.  Includes "this" for instance methods and generative constructors.
+                // parameters: the (source) parameters specific by the TPDTC. Does not include "this"
+                // paramNames: equal in length to argsT. The preferred named for the parameters. Seems to include "this" for instance methods and generative constructors.
                 let args = List.map convVarExprToSrc argsT
                 let paramNames = 
                     // https://github.com/fsprojects/SwaggerProvider/blob/cfb7a665fada77fd0200591f62faba0ba44e172c/src/SwaggerProvider.DesignTime/SwaggerProviderConfig.fs#L79

--- a/tests/BasicGenerativeProvisionTests.fs
+++ b/tests/BasicGenerativeProvisionTests.fs
@@ -13,6 +13,7 @@ open System.Reflection.Emit
 open ProviderImplementation.ProvidedTypes
 open ProviderImplementation.ProvidedTypesTesting
 open Microsoft.FSharp.Quotations
+open Microsoft.FSharp.Quotations.Patterns
 open Microsoft.FSharp.Core.CompilerServices
 open Xunit
 
@@ -100,9 +101,16 @@ type GenerativePropertyProviderWithStaticParams (config : TypeProviderConfig) as
         let adderCode (args: Expr list) = <@@ ignore (%%(args.[1]): System.EventHandler) @@>
         let removerCode (args: Expr list) = <@@ ignore (%%(args.[1]) : System.EventHandler) @@>
         let setterCode (args: Expr list) = <@@ ignore (%%(args.[1]) : string list) @@>
-        let ctorCode (_args: Expr list) = <@@ ignore 1 @@>
+        let ctorCode (args: Expr list) = <@@  ignore 1 @@>
         let cctorCode (_args: Expr list) = <@@ ignore 2 @@>
-        let ctorCode2 (args: Expr list) = <@@ ignore (%%(args.[0]) : string list)  @@>
+        let ctorCode2 (args: Expr list) = 
+            match args.[0] with 
+            | Var v -> if v.Name <> "this" then failwithf "args.[0].Name = %s" v.Name
+            | q -> failwithf "expected Var but got %A" q
+            match args.[1] with 
+            | Var v -> if v.Name <> "arg" then failwithf "args.[1].Name = %s" v.Name
+            | q -> failwithf "expected Var but got %A" q
+            <@@ ignore (%%(args.[1]) : string list)  @@>
 
         let myProp = ProvidedProperty("MyStaticProperty", typeof<string list>, isStatic = true, getterCode = testCode)
         let myProp2 = ProvidedProperty("MyInstaceProperty", typeof<string list>, isStatic = false, getterCode = testCode, setterCode = setterCode)
@@ -111,7 +119,7 @@ type GenerativePropertyProviderWithStaticParams (config : TypeProviderConfig) as
         let myEvent1 = ProvidedEvent("MyEvent", typeof<System.EventHandler>, isStatic = false, adderCode = adderCode, removerCode = removerCode)
         let myCctor1 = ProvidedConstructor([], invokeCode = cctorCode, IsTypeInitializer=true)
         let myCtor1 = ProvidedConstructor([], invokeCode = ctorCode)
-        let myCtor2 = ProvidedConstructor([ProvidedParameter("arg", typeof<string list>)], invokeCode = ctorCode)
+        let myCtor2 = ProvidedConstructor([ProvidedParameter("arg", typeof<string list>)], invokeCode = ctorCode2)
         myType.AddMembers [ (myProp :> MemberInfo); (myProp2 :> MemberInfo); (myMeth1 :> MemberInfo); (myMeth2 :> MemberInfo); (myEvent1 :> MemberInfo); (myCctor1 :> MemberInfo);  (myCtor1 :> MemberInfo);  (myCtor2 :> MemberInfo)]
         myAssem.AddTypes [myType]
         myType

--- a/tests/BasicGenerativeProvisionTests.fs
+++ b/tests/BasicGenerativeProvisionTests.fs
@@ -66,6 +66,9 @@ type GenerativePropertyProviderWithStaticParams (config : TypeProviderConfig) as
                  let rec s14 x = if x = 0 then 1 else s14 (x-1) + s14 (x-1)
                  let rec s14 x = if x = 0 then 1 else s15 x + s15 x
                  and s15 x = s14 (x-1)
+                 let mutable j = 3
+                 for i in [ 1 .. 10 ] do 
+                     j <- j + 1
 
                  //Arithmetic - note, operations such as + are emitted as a call to the method in the F# library, even over integers
                  let z1 = 1 + 1 - 1 * 1 / 1
@@ -158,6 +161,8 @@ let hostedTestCases() =
 let ``GenerativePropertyProviderWithStaticParams generates for correctly``() : unit  = 
     for (text, desc, supports, refs) in testCases() do
         if supports() then 
+            printfn "" 
+            printfn "----- GenerativePropertyProviderWithStaticParams hosted execution: %s ------- " desc 
             let staticArgs = [|  box 3; box 4  |] 
             let runtimeAssemblyRefs = refs()
             let runtimeAssembly = runtimeAssemblyRefs.[0]
@@ -275,10 +280,11 @@ type GenerativeProviderWithRecursiveReferencesToGeneratedTypes (config : TypePro
 let ``GenerativeProviderWithRecursiveReferencesToGeneratedTypes generates correctly``() : unit  = 
     for (text, desc, supports, refs) in testCases() do
         if supports() then 
+            printfn "" 
             printfn "----- GenerativeProviderWithRecursiveReferencesToGeneratedTypes generates correctly: %s ------- " text 
             let staticArgs = [|  box 3; box 4  |] 
             let runtimeAssemblyRefs = refs()
-            printfn "----- refs = %A ------- " runtimeAssemblyRefs
+            //printfn "refs = %A" runtimeAssemblyRefs
 
             let runtimeAssembly = runtimeAssemblyRefs.[0]
             let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, runtimeAssembly, runtimeAssemblyRefs) 
@@ -316,7 +322,7 @@ let ``GenerativeProviderWithRecursiveReferencesToGeneratedTypes generates for ho
             printfn "----- GenerativeProviderWithRecursiveReferencesToGeneratedTypes hosted execution: %s ------- " desc 
             let staticArgs = [|  box 3; box 4  |] 
             let runtimeAssemblyRefs = refs()
-            printfn "----- refs = %A ------- " runtimeAssemblyRefs
+            //printfn "----- refs = %A ------- " runtimeAssemblyRefs
             let runtimeAssembly = runtimeAssemblyRefs.[0]
             let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, runtimeAssembly, runtimeAssemblyRefs, isHostedExecution=true) 
             let tp = GenerativeProviderWithRecursiveReferencesToGeneratedTypes cfg :> TypeProviderForNamespaces


### PR DESCRIPTION
Add testing that checks that "this" is available for generative TP constructors, as part of investigating https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/218