### PR TITLE
addDefaultProbingLocation

### DIFF
--- a/examples/BasicProvider.DesignTime/BasicProvider.Provider.fs
+++ b/examples/BasicProvider.DesignTime/BasicProvider.Provider.fs
@@ -9,7 +9,7 @@ open System.Reflection
 
 [<TypeProvider>]
 type BasicErasingProvider (config : TypeProviderConfig) as this =
-    inherit TypeProviderForNamespaces (config, assemblyReplacementMap=[("BasicProvider.DesignTime", "BasicProvider")])
+    inherit TypeProviderForNamespaces (config, assemblyReplacementMap=[("BasicProvider.DesignTime", "BasicProvider")], addDefaultProbingLocation=true)
 
     let ns = "BasicProvider.Provided"
     let asm = Assembly.GetExecutingAssembly()

--- a/examples/ComboProvider/ComboProvider.fs
+++ b/examples/ComboProvider/ComboProvider.fs
@@ -17,7 +17,7 @@ type SomeRuntimeHelper2() =
 
 [<TypeProvider>]
 type ComboErasingProvider (config : TypeProviderConfig) as this =
-    inherit TypeProviderForNamespaces (config)
+    inherit TypeProviderForNamespaces (config, addDefaultProbingLocation=true)
 
     let ns = "ComboProvider"
     let asm = Assembly.GetExecutingAssembly()

--- a/examples/StressProvider/StressProvider.fs
+++ b/examples/StressProvider/StressProvider.fs
@@ -21,7 +21,7 @@ type Server (name : string) =
 
 [<TypeProvider>]
 type StressErasingProvider (config : TypeProviderConfig) as this =
-    inherit TypeProviderForNamespaces (config)
+    inherit TypeProviderForNamespaces (config, addDefaultProbingLocation=true)
 
     let ns = "StressProvider"
     let asm = Assembly.GetExecutingAssembly()

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -457,7 +457,12 @@ namespace ProviderImplementation.ProvidedTypes
         /// <param name="assemblyReplacementMap">
         ///    Optionally specify a map of assembly names from source model to referenced assemblies.
         /// </param>
-        new: config: TypeProviderConfig * namespaceName:string * types: ProvidedTypeDefinition list * ?sourceAssemblies: Assembly list * ?assemblyReplacementMap: (string * string) list -> TypeProviderForNamespaces
+        ///               
+        /// <param name="addDefaultProbingLocation">
+        ///    Optionally specify that the location of the type provider design-time component should be used to resolve failing assembly resolutions.
+        ///    This flag or an equivalent call to RegisterProbingFolder is generally needed for any type provider design-time components loaded into .NET Core tooling.
+        /// </param>
+        new: config: TypeProviderConfig * namespaceName:string * types: ProvidedTypeDefinition list * ?sourceAssemblies: Assembly list * ?assemblyReplacementMap: (string * string) list * ?addDefaultProbingLocation: bool -> TypeProviderForNamespaces
 
         /// <summary>Initializes a type provider.</summary>
         /// <param name="sourceAssemblies">
@@ -469,7 +474,12 @@ namespace ProviderImplementation.ProvidedTypes
         /// <param name="assemblyReplacementMap">
         ///    Optionally specify a map of assembly names from source model to referenced assemblies.
         /// </param>
-        new: config: TypeProviderConfig * ?sourceAssemblies: Assembly list * ?assemblyReplacementMap: (string * string) list -> TypeProviderForNamespaces
+        ///               
+        /// <param name="addDefaultProbingLocation">
+        ///    Optionally specify that the location of the type provider design-time component should be used to resolve failing assembly resolutions.
+        ///    This flag or an equivalent call to RegisterProbingFolder is generally needed for any type provider design-time components loaded into .NET Core tooling.
+        /// </param>
+        new: config: TypeProviderConfig * ?sourceAssemblies: Assembly list * ?assemblyReplacementMap: (string * string) list * ?addDefaultProbingLocation: bool -> TypeProviderForNamespaces
 
         /// Invoked by the type provider to add a namespace of provided types in the specification of the type provider.
         member AddNamespace: namespaceName:string * types: ProvidedTypeDefinition list -> unit


### PR DESCRIPTION
This adds a new optional argument to TypeProviderForNamespace for adding the location of the TPDTC as a probing location.  This setting is currently necessary (or an explicit use of RegisterProbingFolder is required) for resolving dependencies whenever TPDTC are loaded into F# .NET Core tooling
