### PR TITLE
Fix assembly names in map for generative provider template

### DIFF
--- a/templates/content/basic/src/MyProvider.DesignTime/MyProvider.DesignTime.fs
+++ b/templates/content/basic/src/MyProvider.DesignTime/MyProvider.DesignTime.fs
@@ -63,7 +63,7 @@ type BasicErasingProvider (config : TypeProviderConfig) as this =
 
 [<TypeProvider>]
 type BasicGenerativeProvider (config : TypeProviderConfig) as this =
-    inherit TypeProviderForNamespaces (config, assemblyReplacementMap=[("BasicGenerativeProvider.DesignTime", "MyProvider")])
+    inherit TypeProviderForNamespaces (config, assemblyReplacementMap=[("MyProvider.DesignTime", "MyProvider.Runtime")])
 
     let ns = "MyProvider"
     let asm = Assembly.GetExecutingAssembly()


### PR DESCRIPTION
This fixes the assembly name for generative provider in assembly map in dotnet template. However, I am not so sure, if the Runtime assembly should be used as a replacement, because I couldn't find information on that. That question was raised when @sergey-tihon fixed some [issues ](https://github.com/sergey-tihon/json-provider/blob/da66be7cd9f38a9c46fde28266cf74c1bf70f3c9/src/JsonProvider.DesignTime/JsonProvider.DesignTime.fs#L20)in my provider and it's strange that it works either way (JsonProivder.Runtime or JsonProvider). [Basic provider](https://github.com/fsprojects/FSharp.TypeProviders.SDK/tree/master/examples) uses the Runtime assembly, though.

@dsyme 