### PR TITLE
Use most recent assembly containing type

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -8722,7 +8722,7 @@ namespace ProviderImplementation.ProvidedTypes
                     convTypeDefToTgt t
                     
                 | _ -> 
-                let asms = (if toTgt then getTargetAssemblies() else getSourceAssemblies())
+                let asms = System.Linq.Enumerable.Reverse(if toTgt then getTargetAssemblies() else getSourceAssemblies())
                 let fullName = fixName t.FullName
 
                 // TODO: this linear search through all available source/target assemblies feels as if it must be too slow in some cases.

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -8722,22 +8722,25 @@ namespace ProviderImplementation.ProvidedTypes
                     convTypeDefToTgt t
                     
                 | _ -> 
-                let asms = System.Linq.Enumerable.Reverse(if toTgt then getTargetAssemblies() else getSourceAssemblies())
+                let asms = (if toTgt then getTargetAssemblies() else getSourceAssemblies())
                 let fullName = fixName t.FullName
 
                 // TODO: this linear search through all available source/target assemblies feels as if it must be too slow in some cases.
                 // However, we store type translations in various tables (typeTableFwd and typeTableBwd) so perhaps it is not a problem
-                match asms |> Seq.tryPick (tryGetTypeFromAssembly toTgt t.Assembly.FullName fullName) with
-                | Some (newT, canSave) ->
-                     if canSave then table.[t] <- newT
-                     newT
-                | _ ->
-                    let msg =
-                        if toTgt then sprintf "The design-time type '%O' utilized by a type provider was not found in the target reference assembly set '%A'. You may be referencing a profile which contains fewer types than those needed by the type provider you are using." t (getTargetAssemblies() |> Seq.toList)
-                        elif getSourceAssemblies() |> Seq.length = 0 then sprintf "A failure occured while determining compilation references"
-                        else sprintf "The target type '%O' utilized by a type provider was not found in the design-time assembly set '%A'. Please report this problem to the project site for the type provider." t (getSourceAssemblies() |> Seq.toList)
-                    failwith msg
-
+                let rec loop i = 
+                    if i < 0 then 
+                        let msg =
+                            if toTgt then sprintf "The design-time type '%O' utilized by a type provider was not found in the target reference assembly set '%A'. You may be referencing a profile which contains fewer types than those needed by the type provider you are using." t (getTargetAssemblies() |> Seq.toList)
+                            elif getSourceAssemblies() |> Seq.length = 0 then sprintf "A failure occured while determining compilation references"
+                            else sprintf "The target type '%O' utilized by a type provider was not found in the design-time assembly set '%A'. Please report this problem to the project site for the type provider." t (getSourceAssemblies() |> Seq.toList)
+                        failwith msg
+                    else
+                        match tryGetTypeFromAssembly toTgt t.Assembly.FullName fullName asms.[i] with
+                        | Some (newT, canSave) ->
+                            if canSave then table.[t] <- newT
+                            newT
+                        | None -> loop (i - 1)
+                loop (asms.Count - 1)
 
         and convType toTgt (t:Type) =
             let table = (if toTgt then typeTableFwd else typeTableBwd)


### PR DESCRIPTION
Something like 
```fsharp
    let prop1 = ProvidedProperty("InnerState", typeof<string>, getterCode = fun args -> <@@ "hello" @@>)
    myType.AddMember(prop1)
    let meth2 = ProvidedMethod("InstanceMethod", [], typeof<string>, isStatic=false, invokeCode = (fun args -> Expr.PropertyGet(args.[0],prop1)))
    myType.AddMember(meth2)
```

in a generative type provider has issues in hosted environments. It'll compile fine since the asm only gets generated once but fsi and source checking will fail (particularly if static parameters change). This is due to `ProvidedTypesContext` always returning the first "version" of a given type. The new `invokeCode` will be called but with the wrong type for the `this` parameter resulting in an "incorrect instance type" error. The workaround for source checking would be to either use reflection 
```fsharp
let meth2 = 
    ProvidedMethod("InstanceMethod", [], typeof<string>, isStatic=false, 
        invokeCode = (fun args -> Expr.PropertyGet(args.[0],args.[0].Type.GetProperty("InnerState"))))
```
(which would fail if the type of "InnerState" changes) or to use unchecked expressions. In either case both still have issues when used in fsi.

This is probably the simplest change addressing this issue. It simply favors the most recent assembly containing the desired type instead of the first. However, it leaves open the issue that stale assemblies are not being removed from `ProvidedTypesContext.sourceAssemblies_`.





