### PR TITLE
Read only metadata section

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -6639,18 +6639,18 @@ namespace ProviderImplementation.ProvidedTypes.AssemblyReader
                     n <- n + stream.Read(buffer, n, len-n)
                 buffer
 
-        let ILModuleReaderAfterReadingAllBytes  (file:string, ilGlobals: ILGlobals) =
-            let bytes = File.ReadAllBytes file
-            let key = (file, ilGlobals.systemRuntimeScopeRef.QualifiedName)
+        let ILModuleReaderAfterReadingAllBytes  (fileName:string, ilGlobals: ILGlobals) =
+            let bytes = File.ReadAllBytes fileName
+            let key = (fileName, ilGlobals.systemRuntimeScopeRef.QualifiedName)
             match readersWeakCache.TryGetValue (key) with
             | true, CacheValue mr2  when bytes = mr2.Bytes ->
                 mr2 // throw away the bytes we just read and recycle the existing ILModuleReader
             | _ ->
                 let is = ByteFile(bytes)
-                let pe = PEReader(file, is)
-                let mdchunk = File.ReadBinaryChunk (file, pe.MetadataPhysLoc, pe.MetadataSize)
+                let pe = PEReader(fileName, is)
+                let mdchunk = File.ReadBinaryChunk (fileName, pe.MetadataPhysLoc, pe.MetadataSize)
                 let mdfile = ByteFile(mdchunk)
-                let mr = ILModuleReader(file, mdfile, ilGlobals, true)
+                let mr = ILModuleReader(fileName, mdfile, ilGlobals, true)
                 readersWeakCache.[key] <- CacheValue (mr)
                 mr
 

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -9197,7 +9197,7 @@ namespace ProviderImplementation.ProvidedTypes
             let ilg = ilGlobals.Force()
             let is = ByteFile(bytes)
             let pe = PEReader(fileName, is)
-            let mdchunk = File.ReadBinaryChunk (fileName, pe.MetadataPhysLoc, pe.MetadataSize)
+            let mdchunk = bytes.[pe.MetadataPhysLoc .. pe.MetadataPhysLoc + pe.MetadataSize - 1]
             let mdfile = ByteFile(mdchunk)
             let reader = ILModuleReader(fileName, mdfile, ilg, true)
             TargetAssembly(ilg, this.TryBindILAssemblyRefToTgt, Some reader, fileName) :> Assembly
@@ -14518,12 +14518,12 @@ namespace ProviderImplementation.ProvidedTypes
             assemblyBuilder.Save ()
             //printfn "re-reading generated binary from '%s'" assemblyFileName
             let reader = ILModuleReaderAfterReadingAllBytes(assemblyFileName, ilg)
+            let bytes = File.ReadAllBytes(assemblyFileName)
 #if DEBUG
             printfn "generated binary is at '%s'" assemblyFileName
 #else
             File.Delete assemblyFileName
 #endif
-            let bytes = File.ReadAllBytes(assemblyFileName)
 
             // Use a real Reflection Load when running in F# Interactive
             if isHostedExecution then 

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -4185,9 +4185,10 @@ namespace ProviderImplementation.ProvidedTypes.AssemblyReader
 
     type ByteFile(bytes:byte[]) =
 
-        member __.Bytes = bytes
         member __.ReadByte addr = bytes.[addr]
+
         member __.ReadBytes addr len = Array.sub bytes addr len
+
         member __.CountUtf8String addr =
             let mutable p = addr
             while bytes.[p] <> 0uy do
@@ -6097,7 +6098,6 @@ namespace ProviderImplementation.ProvidedTypes.AssemblyReader
             let ilModule = seekReadModule (ilMetadataVersion) 1
             let ilAssemblyRefs = [ for i in 1 .. getNumRows ILTableNames.AssemblyRef do yield seekReadAssemblyRef i ]
 
-            member __.MetadataBytes = is.Bytes
             member __.ILGlobals = ilg
             member __.ILModuleDef = ilModule
             member __.ILAssemblyRefs = ilAssemblyRefs


### PR DESCRIPTION
This change means that only a ByteFile for the metadata section is kept after cracking DLLs in the ILModuleReader used in type providers.

We should also adjust the PEReader so it doesn't read all bytes, so those are ephemeral

Expected benefit is about 50% reduction in memory usage by TPs built using the TPSDK (since referenced assemblies make up most of the memory usage)
