### PR TITLE
fix for paket pack command

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The template uses paket to acquire the files of the latest published type provid
 
 The type provider also contains the logic necessary to package the type provider:
 
-    .paket\paket.exe pack src\LemonadeProvider.Runtime\paket.template --version 0.0.1
+    .paket\paket.exe pack src\LemonadeProvider.Runtime --version 0.0.1
 
 If you want you can remove the use of paket for the last stage and switch to `dotnet pack` though you'll have to work out how to do that yourself at the moment (it shouldn't be too hard).
 


### PR DESCRIPTION
Before:
```
A:\LemonadeProvider>.paket\paket.exe pack src\LemonadeProvider.Runtime\paket.template --version 0.0.1
Paket version 5.196.2
Performance:
 - Runtime: 539 milliseconds
Paket failed with
-> Unable to create directory A:\LemonadeProvider\src\LemonadeProvider.Runtime\paket.template.
```

After:
```
A:\LemonadeProvider>.paket\paket.exe pack src\LemonadeProvider.Runtime --version 0.0.1
Paket version 5.196.2
Packaging: A:\LemonadeProvider\src\LemonadeProvider.Runtime\paket.template
Wrote: A:\LemonadeProvider\src\LemonadeProvider.Runtime\LemonadeProvider.0.0.1.nupkg
Performance:
 - Runtime: 1 second
```
