### PR TITLE
Add CustomAttribute implementation and open up API slightly for Falanx usage.

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -454,6 +454,8 @@ namespace ProviderImplementation.ProvidedTypes
         assert (ifThenElseOp |> isNull |> not)
         let newUnionCaseOp = qTy.GetMethod("NewNewUnionCaseOp", bindAll)
         assert (newUnionCaseOp |> isNull |> not)
+        let newRecordOp = qTy.GetMethod("NewNewRecordOp", bindAll)
+        assert (newRecordOp |> isNull |> not)
 
         type Microsoft.FSharp.Quotations.Expr with
 
@@ -541,6 +543,10 @@ namespace ProviderImplementation.ProvidedTypes
 
             static member NewUnionCaseUnchecked (uci:Reflection.UnionCaseInfo, args:Expr list) = 
                 let op = newUnionCaseOp.Invoke(null, [| box uci |])
+                mkFEN.Invoke(null, [| box op; box args |]) :?> Expr
+                
+            static member NewRecordUnchecked (ty:Type, args:Expr list) = 
+                let op = newRecordOp.Invoke(null, [| box ty |])
                 mkFEN.Invoke(null, [| box op; box args |]) :?> Expr
                 
         type Shape = Shape of (Expr list -> Expr)

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -572,6 +572,7 @@ namespace ProviderImplementation.ProvidedTypes
         static member LetUnchecked: v:Var * e:Expr * body:Expr -> Expr
         static member IfThenElseUnchecked : e:Expr * t:Expr * f:Expr -> Expr
         static member NewUnionCaseUnchecked : uci:Reflection.UnionCaseInfo * args:Expr list -> Expr
+        static member NewRecordUnchecked : ty:Type * args:Expr list -> Expr
 
       type Shape
       val ( |ShapeCombinationUnchecked|ShapeVarUnchecked|ShapeLambdaUnchecked| ): e:Expr -> Choice<(Shape * Expr list),Var, (Var * Expr)>

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -377,6 +377,7 @@ namespace ProviderImplementation.ProvidedTypes
         /// Add a custom attribute to the provided type definition.
         member AddCustomAttribute: CustomAttributeData -> unit
 
+        /// Returns an array of members that have been overidden along with the ProvidedMethods defining them.
         member internal GetMethodOverrides : unit -> (ProvidedMethod * System.Reflection.MethodInfo) []
 
         /// Emulate the F# type provider type erasure mechanism to get the
@@ -389,6 +390,7 @@ namespace ProviderImplementation.ProvidedTypes
         /// Get or set a utility function to log the creation of root Provided Type. Used to debug caching/invalidation.
         static member Logger: (string -> unit) option ref
 
+        /// Provides a way of setting the Declaring type which is normally done via AddMember/s.
         member PatchDeclaringType : x:ProvidedTypeDefinition -> unit
 
 #if !NO_GENERATIVE


### PR DESCRIPTION
This is all the changes that we had to make to Falanx to consume the TP SDK.

The test I added currently fails due to the way the TP SDK wraps imported types compared to Falanx.

Falanx does not use the Assembly reader and TargetContext which means the call:
```
let attribute = data.Constructor.Invoke(arguments) :?> Attribute
```
Works in Falanx but fails in the test here.  I opened this PR as there was interest in getting CustomAttribute support in the TP sdk although the way we have done this is at odds with the TargetContext mechanism.  I opened a question: #290 To see if there would be a  way around this, or if there might be a reliable way to get access to a RunTimeType.

Myself and @drvink also discussed this, so I though this might be a good place to discuss with the relevant context of the PR.