### PR TITLE
Override `ToString` for `ProvidedAssembly`

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -8091,6 +8091,8 @@ namespace ProviderImplementation.ProvidedTypes
 
         override __.GetTypes () = theTypesArray.Force()
 
+        override __.ToString () = assemblyName.ToString()
+
         override x.GetType (nm: string) = 
             if nm.Contains("+") then
                 let i = nm.LastIndexOf("+")


### PR DESCRIPTION
When reporting an error of missing type in assembly,
https://github.com/fsprojects/FSharp.TypeProviders.SDK/blob/f97f77ba03a8f91d927ab70259dc91eb8ba02e40/src/ProvidedTypes.fs#L14620
uses implicit `ToString`. This causes mono to crash when trying to use
Reflection to get assembly name. This commit patches it by overriding
`ToString`