### PR TITLE
WIP make TP context prep more fully on-demand

### DIFF
--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -428,7 +428,7 @@ namespace ProviderImplementation.ProvidedTypes
         member TryBindSimpleAssemblyNameToTarget: assemblyName: string  -> Choice<Assembly, exn> 
 
         /// Get the list of referenced assemblies determined by the type provider configuration
-        member ReferencedAssemblyPaths: string list
+        member ReferencedAssemblyPaths: string[]
 
         /// Get the resolved referenced assemblies determined by the type provider configuration
         member GetTargetAssemblies : unit -> Assembly[]


### PR DESCRIPTION
WIP fix for #325 

1. delay work preparing a TP that has static parameters by avoiding type translation for the static parameters
2. do not report the common custom attributes on TPs that have static parameters 

The underlying problem is that the mere presence of a provided type like "FSharp.Data.HtmlProvider" (uninstantiated) causes the F# compiler to interrogate that type for its custom attributes.  This eagerly translates both the static paramaters and information int he custom attributes to the target context, causing readers for all the assemblies in the target context to be created.

I've checked this removes the context preparation for unused FSHarp.Data reference

There is a problem with this fix however: the XML doc on a provided type with static parameters is no longer reported to the compiler.  I need to think if/how this can be avoided, it's possible an F# compiler fix/change may be needed to stop it eagerly interrogating the attributes on some types.

