### PR TITLE
Fix typeconversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,5 @@ ProvidedTypes.exe
 .vs/
 .paket/
 test
-packages
+packages/
+paket-files/

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -1075,11 +1075,15 @@ namespace ProviderImplementation.ProvidedTypes
                 this
 
         member __.Parameters = parameters
-        member __.GetInvokeCode = invokeCode
+        member __.DeclaringProvidedType = declaringType
+        member this.GetInvokeCode = 
+            match this.DeclaringProvidedType with
+            | Some dt when dt.IsInterface -> None
+            | _ when this.IsAbstract -> None 
+            | _ -> invokeCode
         member __.StaticParams = staticParams
         member __.StaticParamsApply = staticParamsApply
         member __.BelongsToTargetModel = isTgt
-        member __.DeclaringProvidedType = declaringType
         member this.IsErased = (nonNone "DeclaringType" this.DeclaringProvidedType).IsErased
 
        // Implement overloads
@@ -1087,7 +1091,10 @@ namespace ProviderImplementation.ProvidedTypes
 
         override this.Attributes = 
             match this.DeclaringProvidedType with
-            | Some pt when pt.IsInterface || pt.IsAbstract -> 
+            | Some pt when 
+                pt.IsInterface 
+                || (attrs &&& MethodAttributes.Abstract <> enum 0)
+                || Option.isNone invokeCode  -> 
                     attrs ||| MethodAttributes.Abstract ||| MethodAttributes.Virtual ||| MethodAttributes.HideBySig ||| MethodAttributes.NewSlot
             | _ -> attrs
 

--- a/src/ProvidedTypes.fsi
+++ b/src/ProvidedTypes.fsi
@@ -291,10 +291,10 @@ namespace ProviderImplementation.ProvidedTypes
         inherit TypeDelegator
 
         /// When making a cross-targeting type provider, use this method instead of the corresponding ProvidedTypeDefinition constructor from ProvidedTypes
-        new: className: string * baseType: Type option * ?hideObjectMethods: bool * ?nonNullable: bool * ?isErased: bool * ?isSealed: bool * ?isInterface: bool -> ProvidedTypeDefinition
+        new: className: string * baseType: Type option * ?hideObjectMethods: bool * ?nonNullable: bool * ?isErased: bool * ?isSealed: bool * ?isInterface: bool * ?isAbstract: bool -> ProvidedTypeDefinition
 
         /// When making a cross-targeting type provider, use this method instead of the corresponding ProvidedTypeDefinition constructor from ProvidedTypes
-        new: assembly: Assembly * namespaceName: string * className: string * baseType: Type option * ?hideObjectMethods: bool * ?nonNullable: bool * ?isErased: bool * ?isSealed: bool * ?isInterface: bool -> ProvidedTypeDefinition
+        new: assembly: Assembly * namespaceName: string * className: string * baseType: Type option * ?hideObjectMethods: bool * ?nonNullable: bool * ?isErased: bool * ?isSealed: bool * ?isInterface: bool * ?isAbstract: bool -> ProvidedTypeDefinition
 
         /// Add the given type as an implemented interface.
         member AddInterfaceImplementation: interfaceType: Type -> unit

--- a/tests/FSharp.TypeProviders.SDK.Tests.fsproj
+++ b/tests/FSharp.TypeProviders.SDK.Tests.fsproj
@@ -6,6 +6,7 @@
     <DefineConstants>$(DefineConstants);INTERNAL_FSHARP_TYPEPROVIDERS_SDK_TESTS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
+    <None Include="Script1.fsx" />
     <None Include="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -23,6 +24,8 @@
     <Compile Include="AssemblyReaderTests.fs" />
     <Compile Include="GeneratedOpTests.fs" />
     <Compile Include="GenerativeEnumsProvisionTests.fs" />
+    <Compile Include="GenerativeInterfacesTests.fs" />
+    <Compile Include="GenerativeAbstractClassesTests.fs" />
     <Compile Include="Program.fs" Condition="'$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'netcoreapp3.1' " />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/GenerativeAbstractClassesTests.fs
+++ b/tests/GenerativeAbstractClassesTests.fs
@@ -1,0 +1,123 @@
+#if INTERACTIVE
+#load "../src/ProvidedTypes.fsi" "../src/ProvidedTypes.fs" 
+#load "../src/ProvidedTypesTesting.fs"
+
+#else
+
+module FSharp.TypeProviders.SDK.Tests.GenerativeAbstractClassesTests
+#endif
+
+#nowarn "760" // IDisposable needs new
+
+#if !NO_GENERATIVE
+
+open System
+open System.Reflection
+open Microsoft.FSharp.Core.CompilerServices
+open Xunit
+open ProviderImplementation.ProvidedTypes
+open ProviderImplementation.ProvidedTypesTesting
+
+[<TypeProvider>]
+type GenerativeAbstractClassesProvider (config: TypeProviderConfig) as this =
+    inherit TypeProviderForNamespaces (config)
+
+    let ns = "AbstractClasses.Provided"
+    let tempAssembly = ProvidedAssembly()
+    let container = ProvidedTypeDefinition(tempAssembly, ns, "Contracts", Some typeof<obj>, isErased = false)
+
+    let createAbstractClass name (members: (string * (string * Type) list * Type * bool) list) =
+        let t = ProvidedTypeDefinition(name, Some typeof<System.MarshalByRefObject>, hideObjectMethods = true, isErased = false, isAbstract = true)
+        
+        members
+        |> List.map (fun (name, parameters, retType, isVirtual) ->
+            let ps =
+                parameters
+                |> List.map (fun (name, ty) ->
+                    ProvidedParameter(name, ty))
+            if isVirtual then
+                let m = ProvidedMethod(name, ps, retType, invokeCode = fun args ->
+                    <@ raise (NotImplementedException(name + " is not implemented")) @>.Raw
+                    )
+                m.AddMethodAttrs (MethodAttributes.Virtual ||| MethodAttributes.HasSecurity)
+                m
+            else
+                let m = ProvidedMethod(name, ps, retType)
+                //m.AddMethodAttrs (MethodAttributes.Virtual ||| MethodAttributes.Abstract)
+                m
+            )
+        |> t.AddMembers
+        
+        t
+
+    do
+        let members = [ "GetString", [], typeof<string>, false
+                        "Sum", [("x", typeof<int>); ("y", typeof<int>)], typeof<int>, false ]
+        let contract = createAbstractClass "Contract" members
+        container.AddMember contract
+
+        let members = [ "GetString", [], typeof<string>, true
+                        "Sum", [("x", typeof<int>); ("y", typeof<int>)], typeof<int>, true ]
+        let virtualContract = createAbstractClass "VirtualContract" members
+        container.AddMember virtualContract
+
+        tempAssembly.AddTypes [container]
+        this.AddNamespace(container.Namespace, [container])
+
+let testProvidedAssembly test = 
+    if Targets.supportsFSharp40() then
+        let runtimeAssemblyRefs = Targets.DotNet45FSharp40Refs()
+        let runtimeAssembly = runtimeAssemblyRefs.[0]
+        let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, runtimeAssembly, runtimeAssemblyRefs) 
+        let tp = GenerativeAbstractClassesProvider(cfg) :> TypeProviderForNamespaces
+        let providedNamespace = tp.Namespaces.[0] 
+        let providedTypes  = providedNamespace.GetTypes()
+        let providedType = providedTypes.[0] 
+        let providedTypeDefinition = providedType :?> ProvidedTypeDefinition
+        Assert.Equal("Contracts", providedTypeDefinition.Name)
+
+        let assemContents = (tp :> ITypeProvider).GetGeneratedAssemblyContents(providedTypeDefinition.Assembly)
+        let assembly = Assembly.Load assemContents
+        assembly.ExportedTypes |> Seq.find (fun ty -> ty.Name = "Contracts") |> test
+
+let runningOnMono = try Type.GetType("Mono.Runtime") <> null with _ -> false 
+
+[<Fact>]
+let ``Abstract classes with abstract members are generated correctly``() =
+  // // See tracking bug https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/211 
+  // if not runningOnMono then 
+    testProvidedAssembly <| fun container -> 
+        let contract = container.GetNestedType "Contract"
+        Assert.NotNull contract
+        Assert.True(contract.IsAbstract, "Expected Contract to be an abstract type")
+
+        let contractGetString = contract.GetMethod("GetString")
+        Assert.NotNull contractGetString
+        Assert.True(contractGetString.IsAbstract, "Expected GetString method to be abstract")
+        Assert.True(contractGetString.IsVirtual, "Expected GetString method to be virtual")
+
+        let contractSum = contract.GetMethod("Sum")
+        Assert.NotNull contractSum
+        Assert.True(contractSum.IsAbstract, "Expected Sum method to be abstract")
+        Assert.True(contractSum.IsVirtual, "Expected Sum method to be virtual")
+
+[<Fact>]
+let ``Abstract classes with virtual members are generated correctly``() =
+  // // See tracking bug https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/211 
+  // if not runningOnMono then 
+    testProvidedAssembly <| fun container -> 
+        let contract = container.GetNestedType "VirtualContract"
+        Assert.NotNull contract
+        Assert.True(contract.IsAbstract, "Expected VirtualContract to be an abstract type")
+
+        let contractGetString = contract.GetMethod("GetString")
+        Assert.NotNull contractGetString
+        Assert.False(contractGetString.IsAbstract, "Expected GetString method to not be abstract")
+        Assert.True(contractGetString.IsVirtual, "Expected GetString method to be virtual")
+
+        let contractSum = contract.GetMethod("Sum")
+        Assert.NotNull contractSum
+        Assert.False(contractSum.IsAbstract, "Expected Sum method to not be abstract")
+        Assert.True(contractSum.IsVirtual, "Expected Sum method to be virtual")
+
+#endif

--- a/tests/GenerativeInterfacesTests.fs
+++ b/tests/GenerativeInterfacesTests.fs
@@ -1,0 +1,102 @@
+#if INTERACTIVE
+#load "../src/ProvidedTypes.fsi" "../src/ProvidedTypes.fs" 
+#load "../src/ProvidedTypesTesting.fs"
+
+#else
+
+module FSharp.TypeProviders.SDK.Tests.GenerativeInterfacesTests
+#endif
+
+#nowarn "760" // IDisposable needs new
+
+#if !NO_GENERATIVE
+
+open System
+open System.Reflection
+open Microsoft.FSharp.Core.CompilerServices
+open Xunit
+open ProviderImplementation.ProvidedTypes
+open ProviderImplementation.ProvidedTypesTesting
+
+
+[<TypeProvider>]
+type GenerativeInterfacesProvider (config: TypeProviderConfig) as this =
+    inherit TypeProviderForNamespaces (config)
+
+    let ns = "Interfaces.Provided"
+    let tempAssembly = ProvidedAssembly()
+    let container = ProvidedTypeDefinition(tempAssembly, ns, "Contracts", Some typeof<obj>, isErased = false)
+
+    let createInterface name (members: (string * (string * Type) list * Type) list) =
+        let t = ProvidedTypeDefinition(name, None, isErased = false, isInterface = true)
+
+        members
+        |> List.map (fun (name, parameters, retType) ->
+            let ps = parameters |> List.map (fun (name, ty) -> ProvidedParameter(name, ty))
+            let m = ProvidedMethod(name, ps, retType)
+            //m.SetMethodAttrs (MethodAttributes.PrivateScope ||| MethodAttributes.Public ||| MethodAttributes.Virtual ||| MethodAttributes.HideBySig ||| MethodAttributes.VtableLayoutMask ||| MethodAttributes.Abstract)
+            m.AddMethodAttrs (MethodAttributes.Virtual ||| MethodAttributes.Abstract)
+            m)
+        |> t.AddMembers
+        
+        t
+
+    do
+        let marker = createInterface "IMarker" []
+        container.AddMember marker
+
+        let members = [ "GetString", [], typeof<string>
+                        "Sum", [("x", typeof<int>); ("y", typeof<int>)], typeof<int> ]
+        let contract = createInterface "IContract" members
+        container.AddMember contract
+
+        tempAssembly.AddTypes [container]
+        this.AddNamespace(container.Namespace, [container])
+
+let testProvidedAssembly test = 
+    if Targets.supportsFSharp40() then
+        let runtimeAssemblyRefs = Targets.DotNet45FSharp40Refs()
+        let runtimeAssembly = runtimeAssemblyRefs.[0]
+        let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, runtimeAssembly, runtimeAssemblyRefs) 
+        let tp = GenerativeInterfacesProvider(cfg) :> TypeProviderForNamespaces
+        let providedNamespace = tp.Namespaces.[0] 
+        let providedTypes  = providedNamespace.GetTypes()
+        let providedType = providedTypes.[0] 
+        let providedTypeDefinition = providedType :?> ProvidedTypeDefinition
+        Assert.Equal("Contracts", providedTypeDefinition.Name)
+
+        let assemContents = (tp :> ITypeProvider).GetGeneratedAssemblyContents(providedTypeDefinition.Assembly)
+        let assembly = Assembly.Load assemContents
+        assembly.ExportedTypes |> Seq.find (fun ty -> ty.Name = "Contracts") |> test
+
+let runningOnMono = try Type.GetType("Mono.Runtime") <> null with _ -> false 
+
+[<Fact>]
+let ``Marker interfaces are generated correctly``() =
+  // // See tracking bug https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/211 
+  // if not runningOnMono then 
+    testProvidedAssembly <| fun container -> 
+        let marker = container.GetNestedType "IMarker"
+        Assert.NotNull marker
+        Assert.True(marker.IsInterface, "Expected IMarker to be an interface")
+
+[<Fact>]
+let ``Interfaces with methods are generated correctly``() =
+  // // See tracking bug https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/211 
+  // if not runningOnMono then 
+    testProvidedAssembly <| fun container -> 
+        let contract = container.GetNestedType "IContract"
+        Assert.NotNull contract
+        Assert.True(contract.IsInterface, "Expected IContract to be an interface")
+
+        let contractGetString = contract.GetMethod("GetString")
+        Assert.NotNull contractGetString
+        Assert.True(contractGetString.IsAbstract, "Expected GetString method to be abstract")
+        Assert.True(contractGetString.IsVirtual, "Expected GetString method to be virtual")
+
+        let contractSum = contract.GetMethod("Sum")
+        Assert.NotNull contractSum
+        Assert.True(contractSum.IsAbstract, "Expected Sum method to be abstract")
+        Assert.True(contractSum.IsVirtual, "Expected Sum method to be virtual")
+
+#endif

--- a/tests/Script1.fsx
+++ b/tests/Script1.fsx
@@ -1,0 +1,36 @@
+﻿#r "bin/Release/net461/FSharp.TypeProviders.SDK.Tests.dll"
+
+open System
+
+let comparable = typeof<IComparable>
+comparable.BaseType
+comparable.Attributes
+comparable.GetMethod("CompareTo")
+
+typeof<Collections.IEnumerable>.Attributes
+
+let stream = typeof<IO.Stream>
+stream.BaseType
+stream.Attributes
+stream.GetMethod("Read")
+stream.GetMethod("BeginRead")
+
+let textReader = typeof<IO.TextReader>
+textReader.BaseType
+textReader.Attributes
+
+let streamReader = typeof<IO.StreamReader>
+streamReader.BaseType
+streamReader.Attributes
+
+typeof<obj>.Attributes
+
+
+open FSharp.TypeProviders.SDK.Tests
+
+let t = typeof<FSharp.TypeProviders.SDK.Tests.StaticProperty.SampleTypeProvider>
+let x = t.Assembly.GetTypes()
+x
+|> Array.map (fun t -> t.Name)
+|> Array.sort
+|> Array.filter (fun t -> t.StartsWith("IContract"))


### PR DESCRIPTION
This one is based on previous PR
It is needed to make the WsdlProvider work.

There was a problem when generating the Async methods calls because the Task<ProvidedType> was generated in con convtype using typedef.MakeGenericType(args)... making it a TypeBuilderImplementation Instance that failed on IsAssignableFrom

It should actually be a TypeSymbol2 but the function is at the beginning of the Provided.fs file where this type is not defined yet.

So I introduced a ITypeBuilder interface that enables building GenericTypes, arrays etc that is implemented at the ProvidedTypeBuilder level and passed to previous functions to enable recursive generation 

Once done, it works 👍