### PR TITLE
WIP/RFC Workaround Paket/NuGet issue

### DIFF
--- a/build.fsx
+++ b/build.fsx
@@ -80,7 +80,11 @@ Target.create "Pack" (fun _ ->
         }) "src/FSharp.TypeProviders.SDK.fsproj"
 
     DotNet.pack setParams "examples/BasicProvider.Runtime/BasicProvider.Runtime.fsproj"
-    DotNet.pack setParams "examples/StressProvider/StressProvider.fsproj"
+
+    let sdkVersion = SemVer.parse(DotNet.getVersion id)
+    if sdkVersion >= SemVer.parse("3.1.403") && sdkVersion < SemVer.parse("5.0.0") // we assume the issue is fixed in .net5 - maybe this needs tweaking in any direction
+    then Trace.traceErrorfn "dotnet pack is not supported in combination with paket on dotnet sdk %O (see https://github.com/NuGet/Home/issues/9786). Creation of StressProvider.*.nupkg skipped." sdkVersion
+    else DotNet.pack setParams "examples/StressProvider/StressProvider.fsproj"
 
     DotNet.pack (fun p -> { 
         setParams p with 


### PR DESCRIPTION
Executing the build script fails, when using dotnet sdk 3.1.403 but succeeds with dotnet sdk 3.1.302 (as specified in the [workflow](https://github.com/fsprojects/FSharp.TypeProviders.SDK/actions/runs/331937996/workflow) file).
I was able to trace down the cause to a NuGet/Home#9786 (more details on this may be found in [Slack](https://fsharp.slack.com/archives/C04BJKUP2/p1603891224133900)).

The issue seems to be solved for .net5, but may never be solved for 3.1. In my opinion it would be beneficial when the build could succeed on the current LTS version of the dotnet sdk. To archive this, I've added a version check to disable package creation when an unsupported version is used.

This change could easily be reverted, when the underlying issue is fixed (or the version gets outdated).

Maybe there are better workarounds. Things I've considered:

- Removing the package creation for the StressProvider completely - since functionality will be restored in the future this seems to harsh
- Use `dotnet paket pack` instead of `dotnet pack` - would require transforming the nuspec into [paket.template](https://fsprojects.github.io/Paket/template-files.html) and seems not very welcomed (see Slack & https://twitter.com/BlythMeister/status/1222501608191340545)