### PR TITLE
Don't need to refer to ProvidedTypes.fs at runtime

### DIFF
--- a/templates/content/basic/src/MyProvider.Runtime/paket.references
+++ b/templates/content/basic/src/MyProvider.Runtime/paket.references
@@ -1,4 +1,1 @@
-File:ProvidedTypes.fsi
-File:ProvidedTypes.fs
-
 FSharp.Core


### PR DESCRIPTION
Fixes https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/355