### PR TITLE
ProvidedTypeBuilder.MakeGenericType should use t.MakeGenericType when…

### DIFF
--- a/tests/BasicErasedProvisionTests.fs
+++ b/tests/BasicErasedProvisionTests.fs
@@ -296,6 +296,13 @@ let ``test basic symbol type ops``() =
    t2T.GetConstructors() |> ignore
    t2T.GetMethod("get_Item1") |> ignore
 
+   // MakeGenericType should fallback to classic generic type when neither typedef and arguments are generated
+
+   let t3 = ProvidedTypeBuilder.MakeGenericType(typedefof<seq<_>>, [ typeof<bool> ])
+   Assert.NotEqual<string>("TypeSymbol", t3.GetType().Name ) 
+
+
+
 let stressTestCore() = 
     let refs = Targets.DotNetStandard20FSharpRefs()
     let config = Testing.MakeSimulatedTypeProviderConfig (resolutionFolder=__SOURCE_DIRECTORY__, runtimeAssembly="whatever.dll", runtimeAssemblyRefs=refs)


### PR DESCRIPTION
… all types are not provided

There was a problem in the WsdlProvider with building Task<bool> using ProvidedTypeBuilder.MakeGenericType ...
The generated type was not seen as equal to Task<bool> and AST compilation was failing because of type mismatch.

This PR is detecting when all types are not Provided and simply calls t.MakeGenericType(..) in this case. 