### PR TITLE
Fix MakeGenericType fallback

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -8445,6 +8445,7 @@ namespace ProviderImplementation.ProvidedTypes
                 let hasProvidedArguments =
                     genericArguments
                     |> List.exists (function 
+                        | :? TypeSymbol
                         | :? ProvidedTypeDefinition
                         | :? ProvidedTypeSymbol -> true
                         | _ -> false )

--- a/tests/BasicErasedProvisionTests.fs
+++ b/tests/BasicErasedProvisionTests.fs
@@ -294,6 +294,9 @@ let ``test basic symbol type ops``() =
    let t3 = ProvidedTypeBuilder.MakeGenericType(typedefof<seq<_>>, [ typeof<bool> ])
    Assert.NotEqual<string>("TypeSymbol", t3.GetType().Name ) 
 
+   // MakeGenericType doesn't fallback to classic generic type when type argument is a tuple composed of provided types
+   let t4 = ProvidedTypeBuilder.MakeGenericType(typedefof<seq<_>>, [ t2 ])
+   Assert.Equal<string>("TypeSymbol", t4.GetType().Name ) 
 
 
 let stressTestCore() = 


### PR DESCRIPTION
Fixes an issue introduced in https://github.com/fsprojects/FSharp.TypeProviders.SDK/pull/377, where some kinds of provided types could slip past the fallback check.