### PR TITLE
fix: remove warning about patter discard not allowed for union case that takes no data

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -7529,7 +7529,7 @@ namespace ProviderImplementation.ProvidedTypes
         // See bug https://github.com/fsprojects/FSharp.TypeProviders.SDK/issues/236
         override __.IsSZArray =
             match kind with
-            | TypeSymbolKind.SDArray _ -> true
+            | TypeSymbolKind.SDArray -> true
             | _ -> false
 #endif
         override this.GetMember(_name, _mt, _bindingFlags) = notRequired this "GetMember" this.Name


### PR DESCRIPTION
Before this PR, I get:

```
src/ProvidedTypes.fs(7532,15): warning FS3548: Pattern discard is not allowed for union case that takes no data. 
```