### PR TITLE
Remove AutoOpen from ILTableName

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -3221,8 +3221,6 @@ module internal AssemblyReader =
           systemRuntimeScopeRef: ILScopeRef }
         override __.ToString() = "<ILGlobals>"
 
-    [<AutoOpen>]
-
     [<Struct>]
     type ILTableName(idx: int) =
         member __.Index = idx


### PR DESCRIPTION
Currently it seems not supported feature in F#9 and it seems no longer required to build this file. 

It's quite possible that I miss something. Let's see