### PR TITLE
[Repo Assist] ci: update GitHub Actions from v1 to v4

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,21 +16,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Setup .NET Core
-      # Fix for https://github.com/actions/setup-dotnet/issues/29#issuecomment-548740241
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet }}
 
     - name: Setup .NET Core 6
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.425
 
     - name: Setup .NET Core 8
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.124
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,21 +20,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
 
     - name: Setup .NET Core
-      # Fix for https://github.com/actions/setup-dotnet/issues/29#issuecomment-548740241
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ matrix.dotnet }}
 
     - name: Setup .NET Core 6
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 6.0.425
 
     - name: Setup .NET Core 8
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 8.0.124
 
@@ -52,9 +51,9 @@ jobs:
 
     - name: Deploy documentation from master (unix)
       if: matrix.os != 'windows-latest'
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
-        personal_token: ${{ secrets.GITHUB_TOKEN }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./output
         publish_branch: gh-pages
         force_orphan: true


### PR DESCRIPTION
- actions/checkout@v1  →  actions/checkout@v4
- actions/setup-dotnet@v1  →  actions/setup-dotnet@v4 (×3 per workflow)
- peaceiris/actions-gh-pages@v3  →  @v4 (update token param: personal_token → github_token)

The v1 actions run on Node.js 12 (EOL). The v4 versions use Node.js 20
and benefit from performance and security improvements.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
