### PR TITLE
[Repo Assist] tests: interface inheritance + class-implementing-interface coverage; ci: remove duplicate SDK setup step

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,11 +28,6 @@ jobs:
       with:
         dotnet-version: 6.0.425
 
-    - name: Setup .NET Core 8
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.124
-
     - name: Build on Windows
       if: matrix.os == 'windows-latest'
       run: .\build.cmd

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,11 +32,6 @@ jobs:
       with:
         dotnet-version: 6.0.425
 
-    - name: Setup .NET Core 8
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.124
-
     - name: Build on Windows
       if: matrix.os == 'windows-latest'
       run: .\build.cmd

--- a/tests/GenerativeInterfacesTests.fs
+++ b/tests/GenerativeInterfacesTests.fs
@@ -41,6 +41,24 @@ type GenerativeInterfacesProvider (config: TypeProviderConfig) as this =
         let contract = createInterface "IContract" members
         container.AddMember contract
 
+        // IExtended inherits from IContract and adds an extra method
+        let extended = createInterface "IExtended" [ "GetLength", [("s", typeof<string>)], typeof<int> ]
+        extended.AddInterfaceImplementation(contract)
+        container.AddMember extended
+
+        // Impl is a concrete class that implements both IMarker and IContract
+        let impl = ProvidedTypeDefinition("Impl", Some typeof<obj>, isErased = false)
+        let getString = ProvidedMethod("GetString", [], typeof<string>, invokeCode = fun _args -> <@@ "hello" @@>)
+        getString.AddMethodAttrs(MethodAttributes.Virtual)
+        let sum = ProvidedMethod("Sum", [ProvidedParameter("x", typeof<int>); ProvidedParameter("y", typeof<int>)], typeof<int>,
+                                 invokeCode = fun args -> <@@ (%%args.[1] : int) + (%%args.[2] : int) @@>)
+        sum.AddMethodAttrs(MethodAttributes.Virtual)
+        impl.AddMember getString
+        impl.AddMember sum
+        impl.AddInterfaceImplementation(marker)
+        impl.AddInterfaceImplementation(contract)
+        container.AddMember impl
+
         tempAssembly.AddTypes [container]
         this.AddNamespace(container.Namespace, [container])
 
@@ -88,4 +106,54 @@ let ``Interfaces with methods are generated correctly``() =
         Assert.NotNull contractSum
         Assert.True(contractSum.IsAbstract, "Expected Sum method to be abstract")
         Assert.True(contractSum.IsVirtual, "Expected Sum method to be virtual")
+
+[<Fact>]
+let ``Interface inheritance: IExtended extends IContract``() =
+    testProvidedAssembly <| fun container ->
+        let extended = container.GetNestedType "IExtended"
+        Assert.NotNull(extended)
+        Assert.True(extended.IsInterface, "Expected IExtended to be an interface")
+
+        // IExtended declares its own method
+        let getLength = extended.GetMethod("GetLength")
+        Assert.NotNull(getLength)
+        Assert.True(getLength.IsAbstract, "Expected GetLength to be abstract")
+
+        // IExtended inherits IContract
+        let ifaces = extended.GetInterfaces()
+        let hasIContract = ifaces |> Array.exists (fun i -> i.Name = "IContract")
+        Assert.True(hasIContract, "Expected IExtended to implement IContract")
+
+[<Fact>]
+let ``Concrete class implementing interfaces is generated correctly``() =
+    testProvidedAssembly <| fun container ->
+        let impl = container.GetNestedType "Impl"
+        Assert.NotNull(impl)
+        Assert.False(impl.IsInterface, "Impl should not be an interface")
+        Assert.False(impl.IsAbstract, "Impl should not be abstract")
+
+        // Impl implements both IMarker and IContract
+        let ifaces = impl.GetInterfaces()
+        let hasIMarker  = ifaces |> Array.exists (fun i -> i.Name = "IMarker")
+        let hasIContract = ifaces |> Array.exists (fun i -> i.Name = "IContract")
+        Assert.True(hasIMarker,   "Expected Impl to implement IMarker")
+        Assert.True(hasIContract, "Expected Impl to implement IContract")
+
+[<Fact>]
+let ``Concrete class methods satisfy interface contract``() =
+    testProvidedAssembly <| fun container ->
+        let impl = container.GetNestedType "Impl"
+        Assert.NotNull(impl)
+
+        let getString = impl.GetMethod("GetString")
+        Assert.NotNull(getString)
+        Assert.False(getString.IsAbstract, "GetString on Impl should not be abstract")
+
+        let sum = impl.GetMethod("Sum")
+        Assert.NotNull(sum)
+        let ps = sum.GetParameters()
+        Assert.Equal(2, ps.Length)
+        Assert.Equal(typeof<int>, ps.[0].ParameterType)
+        Assert.Equal(typeof<int>, ps.[1].ParameterType)
+        Assert.Equal(typeof<int>, sum.ReturnType)
 


### PR DESCRIPTION
- Add IExtended (interface inheriting IContract) to GenerativeInterfacesProvider
- Add Impl (concrete class implementing IMarker + IContract)
- Add 3 new Fact tests: IExtended inherits IContract, Impl implements both
  interfaces, and Impl method signatures match the contract
- ci: remove duplicate 'Setup .NET Core 8' step from push.yml and pr.yml;
  the matrix already installs 8.0.124 via the first setup-dotnet step

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
