### PR TITLE
Fix for issue #517

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -14641,6 +14641,7 @@ namespace ProviderImplementation.ProvidedTypes
             | LessThan(None, [t1], [a1; a2]) -> 
                 emitExpr ExpectedStackState.Value a1
                 emitExpr ExpectedStackState.Value a2
+                let t1 = if t1.IsEnum then t1.GetEnumUnderlyingType() else t1
                 match t1 with 
                 | Bool | SByte | Char
                 | Double | Single
@@ -14659,6 +14660,7 @@ namespace ProviderImplementation.ProvidedTypes
             | GreaterThan(None, [t1], [a1; a2]) -> 
                 emitExpr ExpectedStackState.Value a1
                 emitExpr ExpectedStackState.Value a2
+                let t1 = if t1.IsEnum then t1.GetEnumUnderlyingType() else t1
                 match t1 with 
                 | Bool | SByte | Char
                 | Double | Single
@@ -14677,6 +14679,7 @@ namespace ProviderImplementation.ProvidedTypes
             | LessThanOrEqual(None, [t1], [a1; a2]) -> 
                 emitExpr ExpectedStackState.Value a1
                 emitExpr ExpectedStackState.Value a2
+                let t1 = if t1.IsEnum then t1.GetEnumUnderlyingType() else t1
                 match t1 with 
                 | Bool | SByte | Char
                 | Int16 | Int32 | Int64 -> 
@@ -14703,6 +14706,7 @@ namespace ProviderImplementation.ProvidedTypes
             | GreaterThanOrEqual(None, [t1], [a1; a2]) -> 
                 emitExpr ExpectedStackState.Value a1
                 emitExpr ExpectedStackState.Value a2
+                let t1 = if t1.IsEnum then t1.GetEnumUnderlyingType() else t1
                 match t1 with 
                 | Bool | SByte | Char
                 | Int16 | Int32 | Int64 -> 
@@ -14728,6 +14732,7 @@ namespace ProviderImplementation.ProvidedTypes
             | Equals(None, [t1], [a1; a2]) -> 
                 emitExpr ExpectedStackState.Value a1
                 emitExpr ExpectedStackState.Value a2
+                let t1 = if t1.IsEnum then t1.GetEnumUnderlyingType() else t1
                 match t1 with 
                 | Bool | SByte | Char
                 | Double | Single
@@ -14743,6 +14748,7 @@ namespace ProviderImplementation.ProvidedTypes
             | NotEquals(None, [t1], [a1; a2]) -> 
                 emitExpr ExpectedStackState.Value a1
                 emitExpr ExpectedStackState.Value a2
+                let t1 = if t1.IsEnum then t1.GetEnumUnderlyingType() else t1
                 match t1 with 
                 | Bool | SByte | Char
                 | Double | Single

--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -16046,9 +16046,12 @@ namespace ProviderImplementation.ProvidedTypes
 
                             let methLocals = Dictionary<Var, ILLocalBuilder>()
 
-                            let expectedState = if (transType minfo.ReturnType = ILType.Void) then ExpectedStackState.Empty else ExpectedStackState.Value
+                            let retType = transType minfo.ReturnType
+                            let retUnit = retType = ILType.Void || retType.QualifiedName = (transType (convTypeToTgt typeof<unit>)).QualifiedName
+                            let expectedState = if retUnit then ExpectedStackState.Empty else ExpectedStackState.Value
                             let codeGen = CodeGenerator(assemblyMainModule, genUniqueTypeName, implicitCtorArgsAsFields, convTypeToTgt, transType, transFieldSpec, transMeth, transMethRef, transCtorSpec, ilg, methLocals, parameterVars)
                             codeGen.EmitExpr (expectedState, expr)
+                            if retUnit then ilg.Emit(I_ldnull)
                             ilg.Emit I_ret
                       | _ -> ()
 

--- a/tests/GeneratedCodeTests.fs
+++ b/tests/GeneratedCodeTests.fs
@@ -183,3 +183,11 @@ let ``typeof``() =
                     typeof<DateTime>.Name
                 @> "DateTime"
         ]
+
+[<Fact>]
+let ``try-finally with a unit-returning method``() =
+    testProvidedAssembly
+        [
+            (<@@ try ResizeArray<int>().Clear() finally ResizeArray<int>().Clear() @@>),
+            (fun _ -> ()) // just checking for InvalidProgramException
+        ]

--- a/tests/GeneratedOpTests.fs
+++ b/tests/GeneratedOpTests.fs
@@ -1121,3 +1121,15 @@ let ``bitwise not execute correctly``() =
            checkExpr <@ ~~~1234us @>
            checkExpr <@ ~~~12uy @>
        ]
+
+[<Fact>]
+let ``equality on enums``() =
+    testProvidedAssembly
+        [
+            check <@ DateTimeKind.Utc = DateTimeKind.Local @> false
+            check <@ DateTimeKind.Utc <> DateTimeKind.Local @> true
+            check <@ DateTimeKind.Utc < DateTimeKind.Local @> true
+            check <@ DateTimeKind.Utc <= DateTimeKind.Local @> true
+            check <@ DateTimeKind.Utc > DateTimeKind.Local @> false
+            check <@ DateTimeKind.Utc >= DateTimeKind.Local @> false
+        ]


### PR DESCRIPTION
This fixes two minor codegen bugs for generative type providers, as described in issue #517 .

The 4 commits in this PR add a failing test for the first bug, fix the first bug to make the test pass, add a failing test for the second bug, and fix the second bug to make the test pass.