### PR TITLE
Fix invalid IL for generative methods declared with System.Void return type

### DIFF
--- a/src/ProvidedTypes.fs
+++ b/src/ProvidedTypes.fs
@@ -16053,10 +16053,13 @@ namespace ProviderImplementation.ProvidedTypes
                             let methLocals = Dictionary<Var, ILLocalBuilder>()
 
                             let retType = transType minfo.ReturnType
-                            let retUnit = retType = ILType.Void || retType.QualifiedName = (transType (convTypeToTgt typeof<unit>)).QualifiedName
-                            let expectedState = if retUnit then ExpectedStackState.Empty else ExpectedStackState.Value
+                            let retVoid = retType = ILType.Void
+                            let retUnit = not retVoid && retType.QualifiedName = (transType (convTypeToTgt typeof<unit>)).QualifiedName
+                            let expectedState = if retVoid || retUnit then ExpectedStackState.Empty else ExpectedStackState.Value
                             let codeGen = CodeGenerator(assemblyMainModule, genUniqueTypeName, implicitCtorArgsAsFields, convTypeToTgt, transType, transFieldSpec, transMeth, transMethRef, transCtorSpec, ilg, methLocals, parameterVars)
                             codeGen.EmitExpr (expectedState, expr)
+                            // A method whose return type is FSharp.Core Unit must return the (boxed) unit
+                            // value null; a void-returning method must leave the stack empty at ret.
                             if retUnit then ilg.Emit(I_ldnull)
                             ilg.Emit I_ret
                       | _ -> ()

--- a/tests/GenerativeMethodsTests.fs
+++ b/tests/GenerativeMethodsTests.fs
@@ -145,3 +145,54 @@ let ``Generative type has expected method count``() =
     let declaredMethods =
         widgetType.GetMethods(BindingFlags.Instance ||| BindingFlags.Static ||| BindingFlags.Public ||| BindingFlags.DeclaredOnly)
     Assert.Equal(3, declaredMethods.Length)
+
+// ---------------------------------------------------------------------------
+// System.Void return type
+//
+// A ProvidedMethod may be declared with returnType = typeof<System.Void>
+// (transType maps it to ILType.Void). The method body emitter must not push
+// a null on the stack before ret in that case: a void-returning method must
+// have an empty stack at ret, otherwise the IL is invalid and the JIT throws
+// InvalidProgramException when the method is first invoked.
+// ---------------------------------------------------------------------------
+
+[<TypeProvider>]
+type GenerativeVoidReturnProvider (config: TypeProviderConfig) as this =
+    inherit TypeProviderForNamespaces (config)
+
+    let ns = "VoidReturn.Provided"
+    let tempAssembly = ProvidedAssembly()
+    let container = ProvidedTypeDefinition(tempAssembly, ns, "Container", Some typeof<obj>, isErased = false)
+
+    do
+        let widgetType = ProvidedTypeDefinition("Widget", Some typeof<obj>, isErased = false)
+
+        // Static method declared with an explicit System.Void return type
+        let doNothing = ProvidedMethod("DoNothing", [], typeof<System.Void>, invokeCode = (fun _ -> <@@ () @@>), isStatic = true)
+        widgetType.AddMember doNothing
+
+        widgetType.AddMember (ProvidedConstructor([], invokeCode = fun _ -> <@@ () @@>))
+        container.AddMember widgetType
+
+        tempAssembly.AddTypes [container]
+        this.AddNamespace(ns, [container])
+
+[<Fact>]
+let ``Generative method declared with System.Void return type generates valid IL``() =
+    let runtimeAssemblyRefs = Targets.DotNetStandard20FSharpRefs()
+    let runtimeAssembly = runtimeAssemblyRefs.[0]
+    let cfg = Testing.MakeSimulatedTypeProviderConfig (__SOURCE_DIRECTORY__, runtimeAssembly, runtimeAssemblyRefs)
+    let tp = GenerativeVoidReturnProvider(cfg) :> TypeProviderForNamespaces
+    let providedType = tp.Namespaces.[0].GetTypes().[0] :?> ProvidedTypeDefinition
+    let bytes = (tp :> ITypeProvider).GetGeneratedAssemblyContents(providedType.Assembly)
+    let assembly = Assembly.Load bytes
+    let containerType = assembly.ExportedTypes |> Seq.find (fun t -> t.Name = "Container")
+    let widgetType = containerType.GetNestedType("Widget")
+    Assert.NotNull(widgetType)
+
+    let meth = widgetType.GetMethod("DoNothing", BindingFlags.Static ||| BindingFlags.Public)
+    Assert.NotNull(meth)
+    Assert.Equal(typeof<System.Void>, meth.ReturnType)
+
+    // JITs the body; throws InvalidProgramException if a stray ldnull precedes ret
+    meth.Invoke(null, [||]) |> ignore


### PR DESCRIPTION
## Problem

The unit-return fix from #518 emits `I_ldnull` before `I_ret` whenever the method's return type is unit-like:

```fsharp
let retUnit = retType = ILType.Void || retType.QualifiedName = (transType (convTypeToTgt typeof<unit>)).QualifiedName
...
if retUnit then ilg.Emit(I_ldnull)
```

The check also matches `ILType.Void`, so a `ProvidedMethod` declared with `returnType = typeof<System.Void>` (which `transType` maps to `ILType.Void`) gets a stray null pushed onto the stack of a void-returning method. That is invalid IL — the stack must be empty at `ret` in a void method — and the JIT throws `InvalidProgramException` the first time the method is invoked:

```
System.InvalidProgramException : Common Language Runtime detected an invalid program.
   at VoidReturn.Provided.Container.Widget.DoNothing()
```

(The equivalent lambda path in `CodeGenerator.emitLambda` already gets this right: it emits `I_ldnull` only for the FSharp.Core `Unit` return type, not for void.)

## Fix

Split the check: `retVoid` keeps the empty-stack behavior with no `ldnull`; only a genuine FSharp.Core `Unit` return pushes the boxed unit value `null`.

## Testing

* New generative regression test declaring a `System.Void`-returning method and invoking it from the loaded assembly — fails with `InvalidProgramException` before the fix, passes after.
* Full suite green: 161/161 (including the try-finally unit-return test added in #518).

🤖 Generated with [Claude Code](https://claude.com/claude-code)